### PR TITLE
add `@Language("file-reference")` for extra clickability in test utils

### DIFF
--- a/src/test/java/org/snakeyaml/engine/issues/issue149/GlobalDirectivesTest.java
+++ b/src/test/java/org/snakeyaml/engine/issues/issue149/GlobalDirectivesTest.java
@@ -18,6 +18,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.LoadSettings;
@@ -29,7 +31,7 @@ import org.snakeyaml.engine.v2.utils.TestUtils;
 @org.junit.jupiter.api.Tag("fast")
 public class GlobalDirectivesTest {
 
-  Iterable<Event> yamlToEvents(final String resourceName) {
+  Iterable<Event> yamlToEvents(@Language("file-reference") final String resourceName) {
     InputStream input = TestUtils.getResourceAsStream(resourceName);
     Parse parser = new Parse(LoadSettings.builder().build());
     return parser.parseInputStream(input);
@@ -38,7 +40,7 @@ public class GlobalDirectivesTest {
   @Test
   @DisplayName("Use tag directive")
   public void testOneDocument() {
-    Iterable<Event> events = yamlToEvents("issues/issue149-one-document.yaml");
+    Iterable<Event> events = yamlToEvents("/issues/issue149-one-document.yaml");
     final AtomicInteger counter = new AtomicInteger(0);
     events.forEach(event -> counter.incrementAndGet());
 
@@ -48,7 +50,7 @@ public class GlobalDirectivesTest {
   @Test
   @DisplayName("Fail to parse because directive does not stay for the second document")
   public void testDirectives() {
-    Iterable<Event> events = yamlToEvents("issues/issue149-losing-directives.yaml");
+    Iterable<Event> events = yamlToEvents("/issues/issue149-losing-directives.yaml");
     final AtomicInteger counter = new AtomicInteger(0);
     try {
       events.forEach(event -> counter.incrementAndGet());
@@ -60,7 +62,7 @@ public class GlobalDirectivesTest {
   @Test
   @DisplayName("Parse both tag directives")
   public void testDirectives2() {
-    Iterable<Event> events = yamlToEvents("issues/issue149-losing-directives-2.yaml");
+    Iterable<Event> events = yamlToEvents("/issues/issue149-losing-directives-2.yaml");
     final AtomicInteger counter = new AtomicInteger(0);
     events.forEach(event -> counter.incrementAndGet());
 

--- a/src/test/java/org/snakeyaml/engine/issues/issue39/EmitCommentAndSpacesTest.java
+++ b/src/test/java/org/snakeyaml/engine/issues/issue39/EmitCommentAndSpacesTest.java
@@ -39,7 +39,7 @@ public class EmitCommentAndSpacesTest {
   @DisplayName("Issue 39: extra space added")
   void emitCommentWithEvent() {
     LoadSettings loadSettings = LoadSettings.builder().setParseComments(true).build();
-    String input = TestUtils.getResource("issues/issue39-input.yaml");
+    String input = TestUtils.getResource("/issues/issue39-input.yaml");
     Parser parser = new ParserImpl(loadSettings, new StreamReader(loadSettings, input));
     DumpSettings settings = DumpSettings.builder().setDumpComments(true).build();
     StreamDataWriter writer = new StreamToStringWriter();

--- a/src/test/java/org/snakeyaml/engine/issues/issue512/ListWithCommentTest.java
+++ b/src/test/java/org/snakeyaml/engine/issues/issue512/ListWithCommentTest.java
@@ -29,7 +29,7 @@ public class ListWithCommentTest {
   @Test
   @DisplayName("Issue 512 from SnakeYAML")
   public void testList() {
-    String str = TestUtils.getResource("comments/issue512.yaml");
+    String str = TestUtils.getResource("/comments/issue512.yaml");
     LoadSettings options = LoadSettings.builder().setParseComments(true).build();
     Load load = new Load(options);
     List<String> obj = (List<String>) load.loadFromString(str);

--- a/src/test/java/org/snakeyaml/engine/usecases/env/EnvVariableTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/env/EnvVariableTest.java
@@ -43,7 +43,7 @@ class EnvVariableTest {
   public void testDockerCompose() {
     Load loader =
         new Load(LoadSettings.builder().setEnvConfig(Optional.of(new EnvConfig() {})).build());
-    String resource = TestUtils.getResource("env/docker-compose.yaml");
+    String resource = TestUtils.getResource("/env/docker-compose.yaml");
     Map<String, Object> compose = (Map<String, Object>) loader.loadFromString(resource);
     String output = compose.toString();
     assertTrue(output.endsWith(
@@ -59,7 +59,7 @@ class EnvVariableTest {
     System.setProperty(EMPTY, "VVVAAA222");
     Load loader = new Load(
         LoadSettings.builder().setEnvConfig(Optional.of(new CustomEnvConfig(provided))).build());
-    String resource = TestUtils.getResource("env/docker-compose.yaml");
+    String resource = TestUtils.getResource("/env/docker-compose.yaml");
     Map<String, Object> compose = (Map<String, Object>) loader.loadFromString(resource);
     String output = compose.toString();
     assertTrue(output.endsWith(

--- a/src/test/java/org/snakeyaml/engine/usecases/indentation/IndentWithIndicatorTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/indentation/IndentWithIndicatorTest.java
@@ -35,7 +35,7 @@ public class IndentWithIndicatorTest {
     Dump dumper = new Dump(settings);
     String output = dumper.dumpToString(createData());
 
-    String doc = TestUtils.getResource("indentation/issue416-1.yaml");
+    String doc = TestUtils.getResource("/indentation/issue416-1.yaml");
 
     assertEquals(doc, output);
   }
@@ -48,7 +48,7 @@ public class IndentWithIndicatorTest {
     Dump dumper = new Dump(settings);
     String output = dumper.dumpToString(createData());
 
-    String doc = TestUtils.getResource("indentation/issue416-2.yaml");
+    String doc = TestUtils.getResource("/indentation/issue416-2.yaml");
 
     assertEquals(doc, output);
   }
@@ -61,7 +61,7 @@ public class IndentWithIndicatorTest {
     Dump dumper = new Dump(settings);
     String output = dumper.dumpToString(createData());
 
-    String doc = TestUtils.getResource("indentation/issue416_3.yaml");
+    String doc = TestUtils.getResource("/indentation/issue416_3.yaml");
 
     assertEquals(doc, output);
   }

--- a/src/test/java/org/snakeyaml/engine/usecases/inherited/InheritedImportTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/inherited/InheritedImportTest.java
@@ -13,14 +13,6 @@
  */
 package org.snakeyaml.engine.usecases.inherited;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.api.YamlUnicodeReader;
 import org.snakeyaml.engine.v2.events.Event;
@@ -29,29 +21,39 @@ import org.snakeyaml.engine.v2.parser.ParserImpl;
 import org.snakeyaml.engine.v2.scanner.StreamReader;
 import org.snakeyaml.engine.v2.utils.TestUtils;
 
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public abstract class InheritedImportTest {
 
-  public static final String PATH = "inherited_yaml_1_1";
+  public static final String PATH = "/inherited_yaml_1_1";
 
 
   protected String getResource(String theName) {
-    return TestUtils.getResource(PATH + File.separator + theName);
+    //noinspection InjectedReferences
+    return TestUtils.getResource(PATH + "/" + theName);
   }
 
-  protected File[] getStreamsByExtension(String extention) {
-    return getStreamsByExtension(extention, false);
+  protected File[] getStreamsByExtension(String extension) {
+    return getStreamsByExtension(extension, false);
   }
 
-  protected File[] getStreamsByExtension(String extention, boolean onlyIfCanonicalPresent) {
-    File file = new File("src/test/resources/" + PATH);
+  protected File[] getStreamsByExtension(String extension, boolean onlyIfCanonicalPresent) {
+    File file = new File("src/test/resources" + PATH);
     assertTrue(file.exists(), "Folder not found: " + file.getAbsolutePath());
     assertTrue(file.isDirectory());
-    return file.listFiles(new InheritedFilenameFilter(extention, onlyIfCanonicalPresent));
+    return file.listFiles(new InheritedFilenameFilter(extension, onlyIfCanonicalPresent));
   }
 
   protected File getFileByName(String name) {
-    File file = new File("src/test/resources/" + PATH + "/" + name);
+    File file = new File("src/test/resources" + PATH + "/" + name);
     assertTrue(file.exists(), "Folder not found: " + file.getAbsolutePath());
     assertTrue(file.isFile());
     return file;

--- a/src/test/java/org/snakeyaml/engine/usecases/inherited/InheritedMarkTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/inherited/InheritedMarkTest.java
@@ -13,12 +13,12 @@
  */
 package org.snakeyaml.engine.usecases.inherited;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.exceptions.Mark;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @org.junit.jupiter.api.Tag("fast")
 public class InheritedMarkTest extends InheritedImportTest {

--- a/src/test/java/org/snakeyaml/engine/usecases/recursive/RecursiveSetTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/recursive/RecursiveSetTest.java
@@ -31,7 +31,7 @@ class RecursiveSetTest {
   @Test
   @DisplayName("Fail to load map with recursive keys")
   void failToLoadRecursiveSetByDefault() {
-    String recursiveInput = TestUtils.getResource("recursive/recursive-set-1.yaml");
+    String recursiveInput = TestUtils.getResource("/recursive/recursive-set-1.yaml");
     LoadSettings settings = LoadSettings.builder().build();
     Load load = new Load(settings);
     // fail to load map which has only one key - reference to itself
@@ -44,7 +44,7 @@ class RecursiveSetTest {
   @Test
   @DisplayName("Load map with recursive keys if it is explicitly allowed")
   void loadRecursiveSetIfAllowed() {
-    String recursiveInput = TestUtils.getResource("recursive/recursive-set-1.yaml");
+    String recursiveInput = TestUtils.getResource("/recursive/recursive-set-1.yaml");
     LoadSettings settings = LoadSettings.builder().setAllowRecursiveKeys(true).build();
     Load load = new Load(settings);
     // load map which has only one key - reference to itself

--- a/src/test/java/org/snakeyaml/engine/usecases/references/DumpAnchorTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/references/DumpAnchorTest.java
@@ -35,7 +35,7 @@ public class DumpAnchorTest {
 
   @Test
   public void test_anchor_test() {
-    String str = TestUtils.getResource("anchor/issue481.yaml");
+    String str = TestUtils.getResource("/anchor/issue481.yaml");
     Compose compose = new Compose(LoadSettings.builder().build());
     Node node = compose.composeReader(new StringReader(str)).get();
 

--- a/src/test/java/org/snakeyaml/engine/v2/api/LoadMappingTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/api/LoadMappingTest.java
@@ -64,7 +64,7 @@ class LoadMappingTest {
     LoadSettings settings = LoadSettings.builder().build();
     Load load = new Load(settings);
     Map<String, Integer> map =
-        (Map<String, Integer>) load.loadFromString(TestUtils.getResource("load/map1.yaml"));
+        (Map<String, Integer>) load.loadFromString(TestUtils.getResource("/load/map1.yaml"));
     Map<String, Integer> expected = ImmutableMap.of("x", 1, "y", 2, "z", 3);
     assertEquals(expected, map);
   }

--- a/src/test/java/org/snakeyaml/engine/v2/api/LoadSequenceTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/api/LoadSequenceTest.java
@@ -69,7 +69,7 @@ class LoadSequenceTest {
     LoadSettings settings = LoadSettings.builder().build();
     Load load = new Load(settings);
     List<Object> list =
-        (List<Object>) load.loadFromString(TestUtils.getResource("load/list1.yaml"));
+        (List<Object>) load.loadFromString(TestUtils.getResource("/load/list1.yaml"));
     assertEquals(Lists.newArrayList("a", "bb", "ccc", "dddd"), list);
   }
 }

--- a/src/test/java/org/snakeyaml/engine/v2/constructor/StandardConstructorTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/constructor/StandardConstructorTest.java
@@ -29,7 +29,7 @@ class StandardConstructorTest {
   @Test
   void constructMergeExample() {
     Compose compose = new Compose(LoadSettings.builder().build());
-    Optional<Node> node = compose.composeString(TestUtils.getResource("load/list1.yaml"));
+    Optional<Node> node = compose.composeString(TestUtils.getResource("/load/list1.yaml"));
     StandardConstructor constructor = new StandardConstructor(LoadSettings.builder().build());
     Object object = constructor.construct(node.get());
     assertNotNull(object);

--- a/src/test/java/org/snakeyaml/engine/v2/utils/TestUtils.java
+++ b/src/test/java/org/snakeyaml/engine/v2/utils/TestUtils.java
@@ -20,19 +20,20 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.intellij.lang.annotations.Language;
 import org.snakeyaml.engine.v2.events.Event;
 
 public abstract class TestUtils {
 
-  public static String getResource(String theName) {
+  public static String getResource(@Language("file-reference") String theName) {
     InputStream inputStream = getResourceAsStream(theName);
     return new BufferedReader(new InputStreamReader(inputStream)).lines()
         .collect(Collectors.joining("\n", "", "\n"));
   }
 
-  public static InputStream getResourceAsStream(String theName) {
-    InputStream inputStream =
-        Thread.currentThread().getContextClassLoader().getResourceAsStream(theName);
+  public static InputStream getResourceAsStream(@Language("file-reference") String theName) {
+    InputStream inputStream = TestUtils.class.getResourceAsStream(theName);
     if (inputStream == null) {
       throw new RuntimeException("Resource not found: " + theName);
     }


### PR DESCRIPTION
Depends on

* No dependencies!

Minor QOL improvement in the Test DSL. Annotating the file paths with `@Language("file-reference")` means the files can be opened in IntelliJ by ctrl+clicking the file path.

Missing files are highlighted.

![image](https://user-images.githubusercontent.com/897017/222208201-236f47b0-c968-4fef-bcd0-b72dab36d6a6.png)

### Summary of changes

For this to work, 

* all paths need to be absolute from the root resources (all paths were already the full file path, I just needed to add the base `/`)
* use `java.getResouce()` instead of `classLoader.getResource()`.

### Impact

This is a test-only change and does not have any impact on the library.
