### PR TITLE
remove Optional, replace with nullable types

### DIFF
--- a/src/main/java/org/snakeyaml/engine/v2/api/DumpSettings.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/api/DumpSettings.kt
@@ -20,7 +20,6 @@ import org.snakeyaml.engine.v2.common.SpecVersion
 import org.snakeyaml.engine.v2.nodes.Tag
 import org.snakeyaml.engine.v2.schema.Schema
 import org.snakeyaml.engine.v2.serializer.AnchorGenerator
-import java.util.Optional
 
 /**
  * Immutable configuration for serialisation. Description for all the fields can be found in the
@@ -29,9 +28,9 @@ import java.util.Optional
 class DumpSettings internal constructor(
     val isExplicitStart: Boolean,
     val isExplicitEnd: Boolean,
-    @JvmField val explicitRootTag: Optional<Tag>,
+    @JvmField val explicitRootTag: Tag?,
     @JvmField val anchorGenerator: AnchorGenerator,
-    @JvmField val yamlDirective: Optional<SpecVersion>,
+    @JvmField val yamlDirective: SpecVersion?,
     @JvmField val tagDirective: Map<String, String>,
     @JvmField val defaultFlowStyle: FlowStyle,
     @JvmField val defaultScalarStyle: ScalarStyle,

--- a/src/main/java/org/snakeyaml/engine/v2/api/DumpSettingsBuilder.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/api/DumpSettingsBuilder.kt
@@ -25,7 +25,6 @@ import org.snakeyaml.engine.v2.schema.JsonSchema
 import org.snakeyaml.engine.v2.schema.Schema
 import org.snakeyaml.engine.v2.serializer.AnchorGenerator
 import org.snakeyaml.engine.v2.serializer.NumberAnchorGenerator
-import java.util.Optional
 
 /**
  * Builder pattern implementation for DumpSettings
@@ -35,9 +34,9 @@ class DumpSettingsBuilder internal constructor() {
     private var explicitStart = false
     private var explicitEnd = false
     private var nonPrintableStyle: NonPrintableStyle = NonPrintableStyle.ESCAPE
-    private var explicitRootTag: Optional<Tag> = Optional.empty()
+    private var explicitRootTag: Tag? = null
     private var anchorGenerator: AnchorGenerator = NumberAnchorGenerator()
-    private var yamlDirective: Optional<SpecVersion> = Optional.empty()
+    private var yamlDirective: SpecVersion? = null
     private var tagDirective: Map<String, String> = emptyMap()
     private var defaultFlowStyle: FlowStyle = FlowStyle.AUTO
     private var defaultScalarStyle: ScalarStyle = ScalarStyle.PLAIN
@@ -106,7 +105,7 @@ class DumpSettingsBuilder internal constructor() {
      * @param explicitRootTag - specify the root tag
      * @return the builder with the provided value
      */
-    fun setExplicitRootTag(explicitRootTag: Optional<Tag>): DumpSettingsBuilder {
+    fun setExplicitRootTag(explicitRootTag: Tag?): DumpSettingsBuilder {
         this.explicitRootTag = explicitRootTag
         return this
     }
@@ -128,7 +127,7 @@ class DumpSettingsBuilder internal constructor() {
      * @param yamlDirective - the version to be used in the directive
      * @return the builder with the provided value
      */
-    fun setYamlDirective(yamlDirective: Optional<SpecVersion>): DumpSettingsBuilder {
+    fun setYamlDirective(yamlDirective: SpecVersion?): DumpSettingsBuilder {
         this.yamlDirective = yamlDirective
         return this
     }

--- a/src/main/java/org/snakeyaml/engine/v2/api/Load.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/api/Load.kt
@@ -20,7 +20,6 @@ import org.snakeyaml.engine.v2.parser.ParserImpl
 import org.snakeyaml.engine.v2.scanner.StreamReader
 import java.io.InputStream
 import java.io.Reader
-import java.util.Optional
 
 /**
  * Common way to load Java instance(s). This class is not thread-safe. Which means that all the
@@ -168,7 +167,7 @@ class Load @JvmOverloads constructor(
                 hasNext()
             }
             val node = composer.next()
-            return constructor.constructSingleDocument(Optional.of(node))
+            return constructor.constructSingleDocument(node)
         }
 
         override fun remove(): Unit = throw UnsupportedOperationException("Removing is not supported.")

--- a/src/main/java/org/snakeyaml/engine/v2/api/LoadSettings.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/api/LoadSettings.kt
@@ -17,7 +17,6 @@ import org.snakeyaml.engine.v2.common.SpecVersion
 import org.snakeyaml.engine.v2.env.EnvConfig
 import org.snakeyaml.engine.v2.nodes.Tag
 import org.snakeyaml.engine.v2.schema.Schema
-import java.util.Optional
 import java.util.function.Function
 import java.util.function.IntFunction
 import java.util.function.UnaryOperator
@@ -39,7 +38,7 @@ class LoadSettings internal constructor(
     @JvmField val useMarks: Boolean,
     // general
     private val customProperties: Map<SettingKey, Any>,
-    @JvmField val envConfig: Optional<EnvConfig>,
+    @JvmField val envConfig: EnvConfig?,
     @JvmField val parseComments: Boolean,
     @JvmField val codePointLimit: Int,
     @JvmField val schema: Schema,

--- a/src/main/java/org/snakeyaml/engine/v2/api/LoadSettingsBuilder.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/api/LoadSettingsBuilder.kt
@@ -19,7 +19,6 @@ import org.snakeyaml.engine.v2.exceptions.YamlVersionException
 import org.snakeyaml.engine.v2.nodes.Tag
 import org.snakeyaml.engine.v2.schema.JsonSchema
 import org.snakeyaml.engine.v2.schema.Schema
-import java.util.Optional
 import java.util.function.IntFunction
 import java.util.function.UnaryOperator
 
@@ -49,8 +48,7 @@ class LoadSettingsBuilder internal constructor() {
     /** to prevent YAML at https://en.wikipedia.org/wiki/Billion_laughs_attack */
     private var maxAliasesForCollections: Int = 50
     private var useMarks: Boolean = true
-    private var envConfig: Optional<EnvConfig> =
-        Optional.empty() // no ENV substitution by default
+    private var envConfig: EnvConfig? = null // no ENV substitution by default
     private var codePointLimit: Int = 3 * 1024 * 1024 // 3 MB
     private var schema: Schema = JsonSchema()
 
@@ -201,7 +199,7 @@ class LoadSettingsBuilder internal constructor() {
      * @see [Variable
      * substitution](https://bitbucket.org/snakeyaml/snakeyaml-engine/wiki/Documentation.markdown-header-variable-substitution)
      */
-    fun setEnvConfig(envConfig: Optional<EnvConfig>): LoadSettingsBuilder {
+    fun setEnvConfig(envConfig: EnvConfig?): LoadSettingsBuilder {
         this.envConfig = envConfig
         return this
     }

--- a/src/main/java/org/snakeyaml/engine/v2/api/lowlevel/Compose.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/api/lowlevel/Compose.kt
@@ -22,7 +22,6 @@ import org.snakeyaml.engine.v2.scanner.StreamReader
 import java.io.InputStream
 import java.io.Reader
 import java.io.StringReader
-import java.util.Optional
 
 /**
  * Helper to compose input stream to Node
@@ -40,7 +39,7 @@ class Compose(
      * @return parsed [Node] if available
      * @see [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107)
      */
-    fun composeReader(yaml: Reader): Optional<Node> =
+    fun composeReader(yaml: Reader): Node? =
         Composer(
             settings,
             ParserImpl(settings, StreamReader(settings, yaml)),
@@ -54,7 +53,7 @@ class Compose(
      * @return parsed [Node] if available
      * @see [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107)
      */
-    fun composeInputStream(yaml: InputStream): Optional<Node> =
+    fun composeInputStream(yaml: InputStream): Node? =
         Composer(
             settings,
             ParserImpl(settings, StreamReader(settings, YamlUnicodeReader(yaml))),
@@ -67,7 +66,7 @@ class Compose(
      * @return parsed [Node] if available
      * @see [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107)
      */
-    fun composeString(yaml: String): Optional<Node> =
+    fun composeString(yaml: String): Node? =
         Composer(
             settings,
             ParserImpl(settings, StreamReader(settings, StringReader(yaml))),

--- a/src/main/java/org/snakeyaml/engine/v2/comments/CommentLine.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/comments/CommentLine.kt
@@ -15,48 +15,25 @@ package org.snakeyaml.engine.v2.comments
 
 import org.snakeyaml.engine.v2.events.CommentEvent
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * A comment line. Maybe a block comment, blank line, or inline comment.
+ * @param startMark - start position
+ * @param endMark - end position
+ * @param value - Value of this comment
+ * @param commentType - the type
  */
 class CommentLine(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
-    value: String,
-    commentType: CommentType,
+    /**  */
+    @JvmField
+    val startMark: Mark?,
+    @JvmField
+    val endMark: Mark?,
+    @JvmField
+    val value: String,
+    @JvmField
+    val commentType: CommentType,
 ) {
-    /**
-     * getter
-     *
-     * @return start position
-     */
-    @JvmField
-    val startMark: Optional<Mark>
-
-    /**
-     * getter
-     *
-     * @return end position
-     */
-    @JvmField
-    val endMark: Optional<Mark>
-
-    /**
-     * Value of this comment.
-     *
-     * @return comment's value.
-     */
-    @JvmField
-    val value: String
-
-    /**
-     * getter
-     *
-     * @return type of it
-     */
-    @JvmField
-    val commentType: CommentType
 
     /**
      * Create
@@ -65,22 +42,5 @@ class CommentLine(
      */
     constructor(event: CommentEvent) : this(event.startMark, event.endMark, event.value, event.commentType)
 
-    /**
-     * Create
-     *
-     * @param startMark - start
-     * @param endMark - end
-     * @param value - the comment
-     * @param commentType - the type
-     */
-    init {
-        this.startMark = startMark
-        this.endMark = endMark
-        this.value = value
-        this.commentType = commentType
-    }
-
-    override fun toString(): String {
-        return "<" + this.javaClass.name + " (type=" + commentType + ", value=" + value + ")>"
-    }
+    override fun toString(): String = "<${this.javaClass.name} (type=$commentType, value=$value)>"
 }

--- a/src/main/java/org/snakeyaml/engine/v2/common/FlowStyle.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/common/FlowStyle.kt
@@ -18,18 +18,18 @@ package org.snakeyaml.engine.v2.common
  * styles rely on explicit indicators to denote nesting and scope.
  */
 enum class FlowStyle {
-  /**
-   * Flow style
-   */
-  FLOW,
+    /**
+     * Flow style
+     */
+    FLOW,
 
-  /**
-   * Block style
-   */
-  BLOCK,
+    /**
+     * Block style
+     */
+    BLOCK,
 
-  /**
-   * Block style for the root level and flow style for other levels
-   */
-  AUTO
+    /**
+     * Block style for the root level and flow style for other levels
+     */
+    AUTO
 }

--- a/src/main/java/org/snakeyaml/engine/v2/common/NonPrintableStyle.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/common/NonPrintableStyle.kt
@@ -17,13 +17,13 @@ package org.snakeyaml.engine.v2.common
  * Configure the style when String contains non-printable characters
  */
 enum class NonPrintableStyle {
-  /**
-   * Transform non-printable string to !!binary
-   */
-  BINARY,
+    /**
+     * Transform non-printable string to !!binary
+     */
+    BINARY,
 
-  /**
-   * Escape non-printable string with \\u or \\x notation
-   */
-  ESCAPE
+    /**
+     * Escape non-printable string with \\u or \\x notation
+     */
+    ESCAPE
 }

--- a/src/main/java/org/snakeyaml/engine/v2/constructor/core/ConstructYamlCoreBool.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/constructor/core/ConstructYamlCoreBool.kt
@@ -15,7 +15,7 @@ package org.snakeyaml.engine.v2.constructor.core
 
 import org.snakeyaml.engine.v2.constructor.ConstructScalar
 import org.snakeyaml.engine.v2.nodes.Node
-import java.util.*
+import java.util.Locale
 
 /**
  * Create Boolean instances

--- a/src/main/java/org/snakeyaml/engine/v2/constructor/core/ConstructYamlCoreFloat.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/constructor/core/ConstructYamlCoreFloat.kt
@@ -16,7 +16,7 @@ package org.snakeyaml.engine.v2.constructor.core
 import org.snakeyaml.engine.v2.constructor.json.ConstructYamlJsonFloat
 import org.snakeyaml.engine.v2.nodes.Node
 import org.snakeyaml.engine.v2.nodes.ScalarNode
-import java.util.*
+import java.util.Locale
 
 /**
  * Create Double instances for float

--- a/src/main/java/org/snakeyaml/engine/v2/constructor/json/ConstructOptionalClass.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/constructor/json/ConstructOptionalClass.kt
@@ -22,24 +22,20 @@ import org.snakeyaml.engine.v2.resolver.ScalarResolver
 import java.util.Optional
 
 /**
- * Create instances of Optional
+ * Create instances of [Optional]
  */
 class ConstructOptionalClass(private val scalarResolver: ScalarResolver) : ConstructScalar() {
     override fun construct(node: Node?): Optional<Any> {
-        if (node?.nodeType !== NodeType.SCALAR) {
+        if (node?.nodeType != NodeType.SCALAR) {
             throw ConstructorException(
                 "while constructing Optional",
-                Optional.empty(),
+                null,
                 "found non scalar node",
                 node!!.startMark,
             )
         }
         val value = constructScalar(node)
         val implicitTag = scalarResolver.resolve(value, true)
-        return if (implicitTag.equals(Tag.NULL)) {
-            Optional.empty<Any>()
-        } else {
-            Optional.of(value)
-        }
+        return if (implicitTag == Tag.NULL) Optional.empty() else Optional.of(value)
     }
 }

--- a/src/main/java/org/snakeyaml/engine/v2/constructor/json/ConstructUuidClass.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/constructor/json/ConstructUuidClass.kt
@@ -15,14 +15,14 @@ package org.snakeyaml.engine.v2.constructor.json
 
 import org.snakeyaml.engine.v2.constructor.ConstructScalar
 import org.snakeyaml.engine.v2.nodes.Node
-import java.util.*
+import java.util.UUID
 
 /**
  * Create instances of UUID class
  */
 class ConstructUuidClass : ConstructScalar() {
-  override fun construct(node: Node?): UUID {
-    val uuidValue = constructScalar(node)
-    return UUID.fromString(uuidValue)
-  }
+    override fun construct(node: Node?): UUID {
+        val uuidValue = constructScalar(node)
+        return UUID.fromString(uuidValue)
+    }
 }

--- a/src/main/java/org/snakeyaml/engine/v2/emitter/Emitable.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/emitter/Emitable.kt
@@ -19,10 +19,10 @@ import org.snakeyaml.engine.v2.events.Event
  * Define a way to serialize an event to output stream
  */
 fun interface Emitable {
-  /**
-   * Serialise event to bytes
-   *
-   * @param event - the source
-   */
-  fun emit(event: Event)
+    /**
+     * Serialise event to bytes
+     *
+     * @param event - the source
+     */
+    fun emit(event: Event)
 }

--- a/src/main/java/org/snakeyaml/engine/v2/env/EnvConfig.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/env/EnvConfig.kt
@@ -13,29 +13,27 @@
  */
 package org.snakeyaml.engine.v2.env
 
-import java.util.*
-
 /**
  * Configurator for ENV format
  *
  * See [Variable substitution](https://bitbucket.org/snakeyaml/snakeyaml-engine/wiki/Documentation.markdown-header-variable-substitution)
  */
 interface EnvConfig {
-  /**
-   * Implement deviation from the standard logic. TODO implement wiki page
-   *
-   * @param name variable name in the template
-   * @param separator separator in the template, can be `:-`, `-`, `:?`, `?` or `null` if not present
-   * @param value default value or the error in the template or empty if not present
-   * @param environment the value from environment for the provided variable or `null` if unset
-   * @returns the value to apply in the template or empty to follow the standard logic
-   */
-  fun getValueFor(
-      name: String,
-      separator: String?,
-      value: String?,
-      environment: String?,
-  ): Optional<String> {
-    return Optional.empty()
-  }
+    /**
+     * Implement deviation from the standard logic. TODO implement wiki page
+     *
+     * @param name variable name in the template
+     * @param separator separator in the template, can be `:-`, `-`, `:?`, `?` or `null` if not present
+     * @param value default value or the error in the template or empty if not present
+     * @param environment the value from environment for the provided variable or `null` if unset
+     * @returns the value to apply in the template or empty to follow the standard logic
+     */
+    fun getValueFor(
+        name: String,
+        separator: String?,
+        value: String?,
+        environment: String?,
+    ): String? {
+        return null
+    }
 }

--- a/src/main/java/org/snakeyaml/engine/v2/events/AliasEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/AliasEvent.kt
@@ -15,20 +15,19 @@ package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.common.Anchor
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Marks the inclusion of a previously anchored node.
  */
 class AliasEvent @JvmOverloads constructor(
-    anchor: Optional<Anchor>,
-    startMark: Optional<Mark> = Optional.empty(),
-    endMark: Optional<Mark> = Optional.empty(),
+    anchor: Anchor?,
+    startMark: Mark? = null,
+    endMark: Mark? = null,
 ) : NodeEvent(anchor, startMark, endMark) {
     val alias: Anchor
 
     init {
-        alias = anchor.orElseThrow { NullPointerException("Anchor is required in AliasEvent") }
+        alias = anchor ?: throw NullPointerException("Anchor is required in AliasEvent")
     }
 
     override val eventId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/events/CollectionEndEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/CollectionEndEvent.kt
@@ -14,12 +14,11 @@
 package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 /**
  * Base class for the end events of the collection nodes.
  */
 abstract class CollectionEndEvent : Event {
-    constructor(startMark: Optional<Mark>, endMark: Optional<Mark>) : super(startMark, endMark)
+    constructor(startMark: Mark?, endMark: Mark?) : super(startMark, endMark)
     constructor() : super()
 }

--- a/src/main/java/org/snakeyaml/engine/v2/events/CollectionStartEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/CollectionStartEvent.kt
@@ -16,7 +16,6 @@ package org.snakeyaml.engine.v2.events
 import org.snakeyaml.engine.v2.common.Anchor
 import org.snakeyaml.engine.v2.common.FlowStyle
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Base class for the start events of the collection nodes.
@@ -25,18 +24,18 @@ import java.util.*
  * @param[flowStyle] indicates if a collection is block or flow
  */
 abstract class CollectionStartEvent(
-    anchor: Optional<Anchor>,
+    anchor: Anchor?,
 
     /**
      * Tag of this collection.
      *
      * @return The tag of this collection, or `empty` if no explicit tag is available.
      */
-    val tag: Optional<String>,
+    val tag: String?,
     val implicit: Boolean,
     val flowStyle: FlowStyle,
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : NodeEvent(anchor, startMark, endMark) {
 
     /**
@@ -55,9 +54,9 @@ abstract class CollectionStartEvent(
 
     override fun toString(): String {
         return buildString {
-            anchor.ifPresent { a -> append(" &$a") }
+            anchor?.let { a -> append(" &$a") }
             if (!implicit) {
-                tag.ifPresent { theTag: String -> append(" <$theTag>") }
+                tag?.let { theTag: String -> append(" <$theTag>") }
             }
         }
     }

--- a/src/main/java/org/snakeyaml/engine/v2/events/CommentEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/CommentEvent.kt
@@ -15,7 +15,6 @@ package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.comments.CommentType
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Marks a comment block value.
@@ -28,8 +27,8 @@ class CommentEvent(
      * @return Value a comment line string without the leading '#' or a blank line.
      */
     val value: String,
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Event(startMark, endMark) {
 
     override val eventId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/events/DocumentEndEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/DocumentEndEvent.kt
@@ -14,7 +14,6 @@
 package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 /**
  * Marks the end of a document.
@@ -23,8 +22,8 @@ import java.util.Optional
  */
 class DocumentEndEvent @JvmOverloads constructor(
     val isExplicit: Boolean,
-    startMark: Optional<Mark> = Optional.empty(),
-    endMark: Optional<Mark> = Optional.empty(),
+    startMark: Mark? = null,
+    endMark: Mark? = null,
 ) : Event(startMark, endMark) {
 
     override val eventId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/events/DocumentStartEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/DocumentStartEvent.kt
@@ -15,7 +15,6 @@ package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.common.SpecVersion
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 /**
  * Marks the beginning of a document.
@@ -29,7 +28,7 @@ class DocumentStartEvent @JvmOverloads constructor(
     /**
      * @return YAML version the document conforms to.
      */
-    val specVersion: Optional<SpecVersion>,
+    val specVersion: SpecVersion?,
 
     /**
      * Tag shorthands as defined by the `%TAG` directive.
@@ -37,8 +36,8 @@ class DocumentStartEvent @JvmOverloads constructor(
      * @return Mapping of 'handles' to 'prefixes' (the handles include the '!' characters).
      */
     val tags: Map<String, String>,
-    startMark: Optional<Mark> = Optional.empty(),
-    endMark: Optional<Mark> = Optional.empty(),
+    startMark: Mark? = null,
+    endMark: Mark? = null,
 ) : Event(startMark, endMark) {
 
     override val eventId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/events/Event.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/Event.kt
@@ -14,19 +14,18 @@
 package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Basic unit of output from a [org.snakeyaml.engine.v2.parser.Parser] or input of a
  * [org.snakeyaml.engine.v2.emitter.Emitter].
  */
 abstract class Event @JvmOverloads constructor(
-    val startMark: Optional<Mark> = Optional.empty(),
-    val endMark: Optional<Mark> = Optional.empty(),
+    val startMark: Mark? = null,
+    val endMark: Mark? = null,
 ) {
 
     init {
-        if (startMark.isPresent && !endMark.isPresent || !startMark.isPresent && endMark.isPresent) {
+        if (startMark != null && endMark == null || startMark == null && endMark != null) {
             throw NullPointerException("Both marks must be either present or absent.")
         }
     }

--- a/src/main/java/org/snakeyaml/engine/v2/events/MappingEndEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/MappingEndEvent.kt
@@ -14,7 +14,6 @@
 package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Marks the end of a mapping node.
@@ -22,7 +21,7 @@ import java.util.*
  * @see MappingStartEvent
  */
 class MappingEndEvent : CollectionEndEvent {
-    constructor(startMark: Optional<Mark>, endMark: Optional<Mark>) : super(startMark, endMark)
+    constructor(startMark: Mark?, endMark: Mark?) : super(startMark, endMark)
     constructor() : super()
 
     override val eventId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/events/MappingStartEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/MappingStartEvent.kt
@@ -16,7 +16,6 @@ package org.snakeyaml.engine.v2.events
 import org.snakeyaml.engine.v2.common.Anchor
 import org.snakeyaml.engine.v2.common.FlowStyle
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 /**
  * Marks the beginning of a mapping node.
@@ -35,12 +34,12 @@ import java.util.Optional
  * @see MappingEndEvent
  */
 class MappingStartEvent @JvmOverloads constructor(
-    anchor: Optional<Anchor>,
-    tag: Optional<String>,
+    anchor: Anchor?,
+    tag: String?,
     implicit: Boolean,
     flowStyle: FlowStyle,
-    startMark: Optional<Mark> = Optional.empty(),
-    endMark: Optional<Mark> = Optional.empty(),
+    startMark: Mark? = null,
+    endMark: Mark? = null,
 ) : CollectionStartEvent(anchor, tag, implicit, flowStyle, startMark, endMark) {
 
     override val eventId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/events/NodeEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/NodeEvent.kt
@@ -15,7 +15,6 @@ package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.common.Anchor
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 /**
  * Base class for all events that mark the beginning of a node.
@@ -29,7 +28,7 @@ abstract class NodeEvent(
      *
      * @return Anchor of this node or `null` if no anchor is defined.
      */
-    val anchor: Optional<Anchor>,
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    val anchor: Anchor?,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Event(startMark, endMark)

--- a/src/main/java/org/snakeyaml/engine/v2/events/ScalarEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/ScalarEvent.kt
@@ -17,21 +17,20 @@ import org.snakeyaml.engine.v2.common.Anchor
 import org.snakeyaml.engine.v2.common.CharConstants
 import org.snakeyaml.engine.v2.common.ScalarStyle
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 import java.util.stream.Collectors
 
 /**
  * Marks a scalar value.
  */
 class ScalarEvent @JvmOverloads constructor(
-    anchor: Optional<Anchor>,
+    anchor: Anchor?,
 
     /**
      * Tag of this scalar.
      *
      * @returns The tag of this scalar, or `null` if no explicit tag is available.
      */
-    val tag: Optional<String>,
+    val tag: String?,
     // The implicit flag of a scalar event is a pair of boolean values that
     // indicate if the tag may be omitted when the scalar is emitted in a plain
     // and non-plain style correspondingly.
@@ -54,8 +53,8 @@ class ScalarEvent @JvmOverloads constructor(
      * @return Style of the scalar.
      */
     val scalarStyle: ScalarStyle,
-    startMark: Optional<Mark> = Optional.empty(),
-    endMark: Optional<Mark> = Optional.empty(),
+    startMark: Mark? = null,
+    endMark: Mark? = null,
 ) : NodeEvent(anchor, startMark, endMark) {
 
     override val eventId: ID
@@ -67,9 +66,9 @@ class ScalarEvent @JvmOverloads constructor(
     override fun toString(): String {
         return buildString {
             append("=VAL")
-            anchor.ifPresent { a -> append(" &$a") }
+            anchor?.let { a -> append(" &$a") }
             if (implicit.bothFalse()) {
-                tag.ifPresent { theTag: String -> append(" <$theTag>") }
+                tag?.let { theTag: String -> append(" <$theTag>") }
             }
             append(" ")
             append(scalarStyle.toString())

--- a/src/main/java/org/snakeyaml/engine/v2/events/SequenceEndEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/SequenceEndEvent.kt
@@ -14,7 +14,6 @@
 package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 /**
  * Marks the end of a sequence.
@@ -22,7 +21,7 @@ import java.util.Optional
  * @see SequenceStartEvent
  */
 class SequenceEndEvent : CollectionEndEvent {
-    constructor(startMark: Optional<Mark>, endMark: Optional<Mark>) : super(startMark, endMark)
+    constructor(startMark: Mark?, endMark: Mark?) : super(startMark, endMark)
     constructor() : super()
 
     override val eventId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/events/SequenceStartEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/SequenceStartEvent.kt
@@ -16,7 +16,6 @@ package org.snakeyaml.engine.v2.events
 import org.snakeyaml.engine.v2.common.Anchor
 import org.snakeyaml.engine.v2.common.FlowStyle
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 /**
  * Marks the beginning of a sequence node.
@@ -26,12 +25,12 @@ import java.util.Optional
  * @see SequenceEndEvent
  */
 class SequenceStartEvent @JvmOverloads constructor(
-    anchor: Optional<Anchor>,
-    tag: Optional<String>,
+    anchor: Anchor?,
+    tag: String?,
     implicit: Boolean,
     flowStyle: FlowStyle,
-    startMark: Optional<Mark> = Optional.empty(),
-    endMark: Optional<Mark> = Optional.empty(),
+    startMark: Mark? = null,
+    endMark: Mark? = null,
 ) : CollectionStartEvent(anchor, tag, implicit, flowStyle, startMark, endMark) {
 
     override val eventId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/events/StreamEndEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/StreamEndEvent.kt
@@ -14,7 +14,6 @@
 package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Marks the end of a stream that might have contained multiple documents.
@@ -29,7 +28,7 @@ import java.util.*
  *
  */
 class StreamEndEvent : Event {
-    constructor(startMark: Optional<Mark>, endMark: Optional<Mark>) : super(startMark, endMark)
+    constructor(startMark: Mark?, endMark: Mark?) : super(startMark, endMark)
     constructor() : super()
 
     override val eventId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/events/StreamStartEvent.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/events/StreamStartEvent.kt
@@ -14,7 +14,6 @@
 package org.snakeyaml.engine.v2.events
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Marks the start of a stream that might contain multiple documents.
@@ -29,7 +28,7 @@ import java.util.*
  *
  */
 class StreamStartEvent : Event {
-    constructor(startMark: Optional<Mark>, endMark: Optional<Mark>) : super(startMark, endMark)
+    constructor(startMark: Mark?, endMark: Mark?) : super(startMark, endMark)
     constructor() : super()
 
     override val eventId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/exceptions/ComposerException.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/exceptions/ComposerException.kt
@@ -13,8 +13,6 @@
  */
 package org.snakeyaml.engine.v2.exceptions
 
-import java.util.*
-
 /**
  * General exception during composition step
  *
@@ -25,9 +23,9 @@ import java.util.*
  */
 class ComposerException @JvmOverloads constructor(
     problem: String?,
-    problemMark: Optional<Mark>,
+    problemMark: Mark?,
     context: String = "",
-    contextMark: Optional<Mark> = Optional.empty<Mark>(),
+    contextMark: Mark? = null,
 ) : MarkedYamlEngineException(
     context = context,
     contextMark = contextMark,

--- a/src/main/java/org/snakeyaml/engine/v2/exceptions/ConstructorException.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/exceptions/ConstructorException.kt
@@ -13,8 +13,6 @@
  */
 package org.snakeyaml.engine.v2.exceptions
 
-import java.util.Optional
-
 /**
  * General exception during construction step
  * @param cause - the reason
@@ -25,9 +23,9 @@ import java.util.Optional
  */
 open class ConstructorException @JvmOverloads constructor(
     context: String?,
-    contextMark: Optional<Mark>,
+    contextMark: Mark?,
     problem: String?,
-    problemMark: Optional<Mark>,
+    problemMark: Mark?,
     cause: Throwable? = null,
 ) : MarkedYamlEngineException(
     context = context,

--- a/src/main/java/org/snakeyaml/engine/v2/exceptions/DuplicateKeyException.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/exceptions/DuplicateKeyException.kt
@@ -13,8 +13,6 @@
  */
 package org.snakeyaml.engine.v2.exceptions
 
-import java.util.*
-
 /**
  * Indicate duplicate keys in the same mapping during parsing
  *
@@ -23,9 +21,9 @@ import java.util.*
  * @param problemMark - the problem location
  */
 class DuplicateKeyException(
-    contextMark: Optional<Mark>,
+    contextMark: Mark?,
     key: Any,
-    problemMark: Optional<Mark>,
+    problemMark: Mark?,
 ) : ConstructorException(
     context = "while constructing a mapping",
     contextMark = contextMark,

--- a/src/main/java/org/snakeyaml/engine/v2/exceptions/MarkedYamlEngineException.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/exceptions/MarkedYamlEngineException.kt
@@ -13,8 +13,6 @@
  */
 package org.snakeyaml.engine.v2.exceptions
 
-import java.util.*
-
 /**
  * Parsing exception when the marks are available
  *
@@ -26,9 +24,9 @@ import java.util.*
  */
 open class MarkedYamlEngineException protected constructor(
     val context: String?,
-    val contextMark: Optional<Mark>,
+    val contextMark: Mark?,
     val problem: String?,
-    val problemMark: Optional<Mark>,
+    val problemMark: Mark?,
     cause: Throwable? = null,
 ) : YamlEngineException("$context; $problem; $problemMark", cause) {
 
@@ -44,23 +42,23 @@ open class MarkedYamlEngineException protected constructor(
         if (context != null) {
             appendLine(context)
         }
-        if (contextMark.isPresent) {
-            val problemIsPresent = problem != null && problemMark.isPresent
+        if (contextMark != null) {
+            val problemIsPresent = problem != null && problemMark != null
 
             if (
                 !problemIsPresent
-                || contextMark.get().name == problemMark.get().name
-                || contextMark.get().line != problemMark.get().line
-                || contextMark.get().column != problemMark.get().column
+                || contextMark.name == problemMark?.name
+                || contextMark.line != problemMark?.line
+                || contextMark.column != problemMark.column
             ) {
-                appendLine(contextMark.get())
+                appendLine(contextMark)
             }
         }
         if (problem != null) {
             appendLine(problem)
         }
-        if (problemMark.isPresent) {
-            appendLine(problemMark.get())
+        if (problemMark != null) {
+            appendLine(problemMark)
         }
     }
 }

--- a/src/main/java/org/snakeyaml/engine/v2/exceptions/ParserException.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/exceptions/ParserException.kt
@@ -14,7 +14,6 @@
 package org.snakeyaml.engine.v2.exceptions
 
 import org.snakeyaml.engine.v2.parser.Parser
-import java.util.*
 
 /**
  * Exception thrown by the [Parser] implementations in case of malformed input.
@@ -26,9 +25,9 @@ import java.util.*
  */
 class ParserException @JvmOverloads constructor(
     problem: String?,
-    contextMark: Optional<Mark>,
+    contextMark: Mark?,
     context: String? = null,
-    problemMark: Optional<Mark> = Optional.empty<Mark>(),
+    problemMark: Mark? = null,
     cause: Throwable? = null,
 ) : MarkedYamlEngineException(
     context = context,

--- a/src/main/java/org/snakeyaml/engine/v2/exceptions/ScannerException.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/exceptions/ScannerException.kt
@@ -14,7 +14,6 @@
 package org.snakeyaml.engine.v2.exceptions
 
 import org.snakeyaml.engine.v2.scanner.Scanner
-import java.util.Optional
 
 /**
  * Exception thrown by the [Scanner] implementations in case of malformed input.
@@ -26,9 +25,9 @@ import java.util.Optional
  */
 class ScannerException @JvmOverloads constructor(
     problem: String,
-    problemMark: Optional<Mark>,
+    problemMark: Mark?,
     context: String? = null,
-    contextMark: Optional<Mark> = Optional.empty<Mark>(),
+    contextMark: Mark? = null,
     cause: Throwable? = null,
 ) : MarkedYamlEngineException(
     context = context,

--- a/src/main/java/org/snakeyaml/engine/v2/exceptions/YamlVersionException.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/exceptions/YamlVersionException.kt
@@ -20,5 +20,5 @@ import org.snakeyaml.engine.v2.common.SpecVersion
  * @param specVersion - the specified version
  */
 class YamlVersionException(
-    val specVersion: SpecVersion,
+    specVersion: SpecVersion,
 ) : YamlEngineException(specVersion.toString())

--- a/src/main/java/org/snakeyaml/engine/v2/nodes/AnchorNode.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/nodes/AnchorNode.kt
@@ -18,10 +18,10 @@ package org.snakeyaml.engine.v2.nodes
  * @param realNode - the source node
  */
 class AnchorNode(
-  /** @returns the origin */
-  val realNode: Node
+    /** @returns the origin */
+    val realNode: Node,
 ) : Node(realNode.tag, realNode.startMark, realNode.endMark) {
 
-  override val nodeType: NodeType
-    get() = NodeType.ANCHOR
+    override val nodeType: NodeType
+        get() = NodeType.ANCHOR
 }

--- a/src/main/java/org/snakeyaml/engine/v2/nodes/CollectionNode.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/nodes/CollectionNode.kt
@@ -15,7 +15,6 @@ package org.snakeyaml.engine.v2.nodes
 
 import org.snakeyaml.engine.v2.common.FlowStyle
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Base class for the two collection types [mapping][MappingNode] and [ collection][SequenceNode].
@@ -23,21 +22,21 @@ import java.util.*
  * @param[flowStyle] Serialization style of this collection
  */
 abstract class CollectionNode<T> @JvmOverloads constructor(
-  tag: Tag,
-  var flowStyle: FlowStyle,
-  startMark: Optional<Mark>,
-  endMark: Optional<Mark>,
-  resolved: Boolean = true,
+    tag: Tag,
+    var flowStyle: FlowStyle,
+    startMark: Mark?,
+    endMark: Mark?,
+    resolved: Boolean = true,
 ) : Node(tag, startMark, endMark, resolved = resolved) {
 
-  /**
-   * Returns the elements in this sequence.
-   *
-   * @return Nodes in the specified order.
-   */
-  abstract val value: List<T>?
+    /**
+     * Returns the elements in this sequence.
+     *
+     * @return Nodes in the specified order.
+     */
+    abstract val value: List<T>?
 
-  fun setEndMark(value: Optional<Mark>) {
-    super.endMark = value
-  }
+    fun setEndMark(value: Mark?) {
+        super.endMark = value
+    }
 }

--- a/src/main/java/org/snakeyaml/engine/v2/nodes/MappingNode.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/nodes/MappingNode.kt
@@ -15,7 +15,6 @@ package org.snakeyaml.engine.v2.nodes
 
 import org.snakeyaml.engine.v2.common.FlowStyle
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Represents a map.
@@ -31,35 +30,35 @@ import java.util.*
  * @param[endMark] end
  */
 class MappingNode @JvmOverloads constructor(
-  tag: Tag,
-  /**
-   * Applications may need to replace the content (Spring Boot).
-   * Merging was removed, but it may be implemented.
-   */
-  override var value: MutableList<NodeTuple>,
-  flowStyle: FlowStyle,
-  resolved: Boolean = true,
-  startMark: Optional<Mark> = Optional.empty<Mark>(),
-  endMark: Optional<Mark> = Optional.empty<Mark>(),
+    tag: Tag,
+    /**
+     * Applications may need to replace the content (Spring Boot).
+     * Merging was removed, but it may be implemented.
+     */
+    override var value: MutableList<NodeTuple>,
+    flowStyle: FlowStyle,
+    resolved: Boolean = true,
+    startMark: Mark? = null,
+    endMark: Mark? = null,
 ) : CollectionNode<NodeTuple>(
-  tag = tag,
-  flowStyle = flowStyle,
-  startMark = startMark,
-  endMark = endMark,
-  resolved = resolved,
+    tag = tag,
+    flowStyle = flowStyle,
+    startMark = startMark,
+    endMark = endMark,
+    resolved = resolved,
 ) {
 
-  override val nodeType: NodeType
-    get() = NodeType.MAPPING
+    override val nodeType: NodeType
+        get() = NodeType.MAPPING
 
-  override fun toString(): String {
-    val values = value.joinToString("") { node ->
-      val valueNode: Any = when (node.valueNode) {
-        is CollectionNode<*> -> System.identityHashCode(node.valueNode) // avoid overflow in case of recursive structures
-        else                 -> node
-      }
-      "{ key=${node.keyNode}; value=$valueNode }"
+    override fun toString(): String {
+        val values = value.joinToString("") { node ->
+            val valueNode: Any = when (node.valueNode) {
+                is CollectionNode<*> -> System.identityHashCode(node.valueNode) // avoid overflow in case of recursive structures
+                else                 -> node
+            }
+            "{ key=${node.keyNode}; value=$valueNode }"
+        }
+        return "<${this.javaClass.name} (tag=$tag, values=$values)>"
     }
-    return "<${this.javaClass.name} (tag=$tag, values=$values)>"
-  }
 }

--- a/src/main/java/org/snakeyaml/engine/v2/nodes/Node.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/nodes/Node.kt
@@ -16,7 +16,6 @@ package org.snakeyaml.engine.v2.nodes
 import org.snakeyaml.engine.v2.comments.CommentLine
 import org.snakeyaml.engine.v2.common.Anchor
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Base class for all nodes.
@@ -39,10 +38,10 @@ abstract class Node @JvmOverloads constructor(
      */
     var tag: Tag,
 
-    val startMark: Optional<Mark>,
+    val startMark: Mark?,
 
     @JvmField
-    var endMark: Optional<Mark>,
+    var endMark: Mark?,
 
     /**
      * `true` when the tag is assigned by the resolver
@@ -78,7 +77,7 @@ abstract class Node @JvmOverloads constructor(
      *
      * @see [3.2.2.2. Anchors and Aliases](https://yaml.org/spec/1.2/spec.html.id2765878)
      */
-    var anchor: Optional<Anchor> = Optional.empty()
+    var anchor: Anchor? = null
 
     /**
      * The ordered list of in-line comments. The first of which appears at the end of the line

--- a/src/main/java/org/snakeyaml/engine/v2/nodes/NodeType.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/nodes/NodeType.kt
@@ -17,8 +17,8 @@ package org.snakeyaml.engine.v2.nodes
  * Enum for the basic YAML types: scalar, sequence and mapping.
  */
 enum class NodeType {
-  SCALAR,
-  SEQUENCE,
-  MAPPING,
-  ANCHOR,
+    SCALAR,
+    SEQUENCE,
+    MAPPING,
+    ANCHOR,
 }

--- a/src/main/java/org/snakeyaml/engine/v2/nodes/ScalarNode.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/nodes/ScalarNode.kt
@@ -15,7 +15,6 @@ package org.snakeyaml.engine.v2.nodes
 
 import org.snakeyaml.engine.v2.common.ScalarStyle
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Represents a scalar node.
@@ -31,19 +30,19 @@ import java.util.*
  * @see org.snakeyaml.engine.v2.events.ScalarEvent
  */
 class ScalarNode @JvmOverloads constructor(
-  tag: Tag,
-  val value: String,
-  val scalarStyle: ScalarStyle,
-  resolved: Boolean = true,
-  startMark: Optional<Mark> = Optional.empty<Mark>(),
-  endMark: Optional<Mark> = Optional.empty<Mark>(),
+    tag: Tag,
+    val value: String,
+    val scalarStyle: ScalarStyle,
+    resolved: Boolean = true,
+    startMark: Mark? = null,
+    endMark: Mark? = null,
 ) : Node(tag, startMark, endMark, resolved = resolved) {
 
-  override val nodeType: NodeType
-    get() = NodeType.SCALAR
+    override val nodeType: NodeType
+        get() = NodeType.SCALAR
 
-  override fun toString(): String = "<${this.javaClass.name} (tag=$tag, value=$value)>"
+    override fun toString(): String = "<${this.javaClass.name} (tag=$tag, value=$value)>"
 
-  val isPlain: Boolean
-    get() = scalarStyle == ScalarStyle.PLAIN
+    val isPlain: Boolean
+        get() = scalarStyle == ScalarStyle.PLAIN
 }

--- a/src/main/java/org/snakeyaml/engine/v2/nodes/SequenceNode.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/nodes/SequenceNode.kt
@@ -15,7 +15,6 @@ package org.snakeyaml.engine.v2.nodes
 
 import org.snakeyaml.engine.v2.common.FlowStyle
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.*
 
 /**
  * Represents a sequence.
@@ -29,8 +28,8 @@ class SequenceNode @JvmOverloads constructor(
     override val value: List<Node>,
     flowStyle: FlowStyle,
     resolved: Boolean = true,
-    startMark: Optional<Mark> = Optional.empty<Mark>(),
-    endMark: Optional<Mark> = Optional.empty<Mark>(),
+    startMark: Mark? = null,
+    endMark: Mark? = null,
 ) : CollectionNode<Node>(
     tag,
     flowStyle,

--- a/src/main/java/org/snakeyaml/engine/v2/parser/VersionTagsTuple.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/parser/VersionTagsTuple.kt
@@ -14,13 +14,12 @@
 package org.snakeyaml.engine.v2.parser
 
 import org.snakeyaml.engine.v2.common.SpecVersion
-import java.util.Optional
 
 /**
  * Store the internal state for directives
  */
 internal data class VersionTagsTuple(
-    val specVersion: Optional<SpecVersion>,
+    val specVersion: SpecVersion?,
     val tags: Map<String, String>,
 ) {
     override fun toString(): String = "VersionTagsTuple<$specVersion, $tags>"

--- a/src/main/java/org/snakeyaml/engine/v2/resolver/CoreScalarResolver.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/resolver/CoreScalarResolver.kt
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.snakeyaml.engine.v2.resolver;
+package org.snakeyaml.engine.v2.resolver
 
 import org.snakeyaml.engine.v2.nodes.Tag
 import java.util.regex.Pattern
@@ -21,20 +21,20 @@ import java.util.regex.Pattern
  */
 class CoreScalarResolver : BaseScalarResolver(
     {
-        addImplicitResolver(Tag.NULL, EMPTY, null);
-        addImplicitResolver(Tag.BOOL, BOOL, "tfTF");
+        addImplicitResolver(Tag.NULL, EMPTY, null)
+        addImplicitResolver(Tag.BOOL, BOOL, "tfTF")
         // INT must be before FLOAT because the regular expression for FLOAT matches INT
-        addImplicitResolver(Tag.INT, INT, "-+0123456789");
-        addImplicitResolver(Tag.FLOAT, FLOAT, "-+0123456789.");
-        addImplicitResolver(Tag.NULL, NULL, "n\u0000");
-        addImplicitResolver(Tag.ENV_TAG, ENV_FORMAT.toPattern(), "$");
+        addImplicitResolver(Tag.INT, INT, "-+0123456789")
+        addImplicitResolver(Tag.FLOAT, FLOAT, "-+0123456789.")
+        addImplicitResolver(Tag.NULL, NULL, "n\u0000")
+        addImplicitResolver(Tag.ENV_TAG, ENV_FORMAT.toPattern(), "$")
     },
 ) {
 
     companion object {
 
         /** Boolean as defined in Core */
-        val BOOL: Pattern = Pattern.compile("^(?:true|True|TRUE|false|False|FALSE)$");
+        val BOOL: Pattern = Pattern.compile("^(?:true|True|TRUE|false|False|FALSE)$")
 
         /**
          * Float as defined in JSON (Number which is Float).
@@ -54,10 +54,10 @@ class CoreScalarResolver : BaseScalarResolver(
             "^([-+]?[0-9]+)" + // (base 10)
                 "|(0o[0-7]+)" + // (base 8)
                 "|(0x[0-9a-fA-F]+)$", // (base 16)
-        );
+        )
 
         /** Null as defined in Core */
-        val NULL: Pattern = Pattern.compile("^(?:~|null|Null|NULL| )$");
+        val NULL: Pattern = Pattern.compile("^(?:~|null|Null|NULL| )$")
 
     }
 }

--- a/src/main/java/org/snakeyaml/engine/v2/resolver/ScalarResolver.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/resolver/ScalarResolver.kt
@@ -19,12 +19,12 @@ import org.snakeyaml.engine.v2.nodes.Tag
  * `ScalarResolver` tries to detect a type of scalar value by its content (when the tag is implicit)
  */
 fun interface ScalarResolver {
-  /**
-   * Resolve (detect) the tag of the scalar node of the given type.
-   *
-   * @param value - the value of the scalar node
-   * @param implicit - true if there was no tag specified (the tag will be resolved)
-   * @return the Tag that matches the contents
-   */
-  fun resolve(value: String, implicit: Boolean): Tag
+    /**
+     * Resolve (detect) the tag of the scalar node of the given type.
+     *
+     * @param value - the value of the scalar node
+     * @param implicit - true if there was no tag specified (the tag will be resolved)
+     * @return the Tag that matches the contents
+     */
+    fun resolve(value: String, implicit: Boolean): Tag
 }

--- a/src/main/java/org/snakeyaml/engine/v2/scanner/SimpleKey.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/scanner/SimpleKey.kt
@@ -14,7 +14,6 @@
 package org.snakeyaml.engine.v2.scanner
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 /**
  * Simple keys treatment.
@@ -27,7 +26,7 @@ internal class SimpleKey(
     val index: Int,
     val line: Int,
     val column: Int,
-    val mark: Optional<Mark>,
+    val mark: Mark?,
 ) {
     override fun toString(): String =
         "SimpleKey - tokenNumber=$tokenNumber required=$isRequired index=$index line=$line column=$column"

--- a/src/main/java/org/snakeyaml/engine/v2/scanner/StreamReader.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/scanner/StreamReader.kt
@@ -92,20 +92,18 @@ class StreamReader(
      *
      * @return [Mark] of the current position or empty [Optional] otherwise
      */
-    fun getMark(): Optional<Mark> {
+    fun getMark(): Mark? {
         return if (useMarks) {
-            Optional.of(
-                Mark(
-                    name = name,
-                    index = index,
-                    line = line,
-                    column = column,
-                    buffer = codePointsWindow,
-                    pointer = pointer,
-                ),
+            Mark(
+                name = name,
+                index = index,
+                line = line,
+                column = column,
+                buffer = codePointsWindow,
+                pointer = pointer,
             )
         } else {
-            Optional.empty()
+            null
         }
     }
 
@@ -198,7 +196,7 @@ class StreamReader(
                         read++
                     }
                 }
-                var nonPrintable: Optional<Int> = Optional.empty()
+                var nonPrintable: Int? = null
                 var i = 0
                 while (i < read) {
                     val codePoint = Character.codePointAt(buffer, i)
@@ -206,18 +204,18 @@ class StreamReader(
                     if (isPrintable(codePoint)) {
                         i += Character.charCount(codePoint)
                     } else {
-                        nonPrintable = Optional.of(codePoint)
+                        nonPrintable = codePoint
                         i = read
                     }
                     cpIndex++
                 }
                 dataLength = cpIndex
                 pointer = 0
-                if (nonPrintable.isPresent) {
+                if (nonPrintable != null) {
                     throw ReaderException(
                         name = name,
                         position = cpIndex - 1,
-                        codePoint = nonPrintable.get(),
+                        codePoint = nonPrintable,
                         message = "special characters are not allowed",
                     )
                 }

--- a/src/main/java/org/snakeyaml/engine/v2/serializer/AnchorGenerator.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/serializer/AnchorGenerator.kt
@@ -20,11 +20,11 @@ import org.snakeyaml.engine.v2.nodes.Node
  * Functional interface to define Anchor for dumping
  */
 fun interface AnchorGenerator {
-  /**
-   * Create anchor
-   *
-   * @param node - the node to refer to
-   * @return unique name
-   */
-  fun nextAnchor(node: Node): Anchor
+    /**
+     * Create anchor
+     *
+     * @param node - the node to refer to
+     * @return unique name
+     */
+    fun nextAnchor(node: Node): Anchor
 }

--- a/src/main/java/org/snakeyaml/engine/v2/serializer/NumberAnchorGenerator.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/serializer/NumberAnchorGenerator.kt
@@ -22,7 +22,7 @@ import org.snakeyaml.engine.v2.nodes.Node
  * @param lastAnchorId - the number to start from
  */
 class NumberAnchorGenerator(
-    private var lastAnchorId: UInt = 0u
+    private var lastAnchorId: UInt = 0u,
 ) : AnchorGenerator {
     /**
      * Create value increasing the number

--- a/src/main/java/org/snakeyaml/engine/v2/serializer/Serializer.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/serializer/Serializer.kt
@@ -36,7 +36,6 @@ import org.snakeyaml.engine.v2.nodes.NodeType
 import org.snakeyaml.engine.v2.nodes.ScalarNode
 import org.snakeyaml.engine.v2.nodes.SequenceNode
 import org.snakeyaml.engine.v2.nodes.Tag
-import java.util.Optional
 
 /**
  * Transform a [Node] Graph to [org.snakeyaml.engine.v2.events.Event] stream and allow provided [Emitable] to present the
@@ -66,7 +65,7 @@ class Serializer(
             ),
         )
         anchorNode(node)
-        settings.explicitRootTag.ifPresent { tag -> node.tag = tag }
+        settings.explicitRootTag?.let { tag -> node.tag = tag }
         serializeNode(node)
         emitable.emit(DocumentEndEvent(settings.isExplicitEnd))
         serializedNodes.clear()
@@ -92,7 +91,7 @@ class Serializer(
             anchors.computeIfAbsent(realNode) { settings.anchorGenerator.nextAnchor(realNode) }
         } else {
             anchors[realNode] =
-                if (realNode.anchor.isPresent) {
+                if (realNode.anchor != null) {
                     settings.anchorGenerator.nextAnchor(realNode)
                 } else {
                     null
@@ -126,7 +125,7 @@ class Serializer(
     private fun serializeNode(node: Node) {
         val realNode = if (node is AnchorNode) node.realNode else node
 
-        val tAlias = Optional.ofNullable(anchors[realNode])
+        val tAlias = (anchors[realNode])
         if (serializedNodes.contains(realNode)) {
             emitable.emit(AliasEvent(tAlias))
         } else {
@@ -143,7 +142,7 @@ class Serializer(
                     )
                     val event = ScalarEvent(
                         anchor = tAlias,
-                        tag = Optional.of(realNode.tag.value),
+                        tag = realNode.tag.value,
                         implicit = tuple,
                         value = realNode.value,
                         scalarStyle = realNode.scalarStyle,
@@ -160,7 +159,7 @@ class Serializer(
                     emitable.emit(
                         SequenceStartEvent(
                             anchor = tAlias,
-                            tag = Optional.of(realNode.tag.value),
+                            tag = realNode.tag.value,
                             implicit = implicitS,
                             flowStyle = realNode.flowStyle,
                         ),
@@ -180,11 +179,11 @@ class Serializer(
                         emitable.emit(
                             MappingStartEvent(
                                 anchor = tAlias,
-                                tag = Optional.of(realNode.tag.value),
+                                tag = realNode.tag.value,
                                 implicit = realNode.tag == Tag.MAP,
                                 flowStyle = realNode.flowStyle,
-                                startMark = Optional.empty(),
-                                endMark = Optional.empty(),
+                                startMark = null,
+                                endMark = null,
                             ),
                         )
                         for ((key, value) in realNode.value) {

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/AliasToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/AliasToken.kt
@@ -15,12 +15,11 @@ package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.common.Anchor
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class AliasToken(
     val value: Anchor,
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.Alias

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/AnchorToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/AnchorToken.kt
@@ -15,12 +15,11 @@ package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.common.Anchor
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class AnchorToken(
     val value: Anchor,
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
 
     override val tokenId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/BlockEndToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/BlockEndToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class BlockEndToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.BlockEnd

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/BlockEntryToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/BlockEntryToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class BlockEntryToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.BlockEntry

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/BlockMappingStartToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/BlockMappingStartToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class BlockMappingStartToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.BlockMappingStart

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/BlockSequenceStartToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/BlockSequenceStartToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class BlockSequenceStartToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.BlockSequenceStart

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/CommentToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/CommentToken.kt
@@ -15,13 +15,12 @@ package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.comments.CommentType
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class CommentToken(
     val commentType: CommentType,
     val value: String,
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
 
     override val tokenId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/DirectiveToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/DirectiveToken.kt
@@ -14,12 +14,11 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class DirectiveToken(
     val value: TokenValue?,
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
 
     override val tokenId: ID

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/DocumentEndToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/DocumentEndToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class DocumentEndToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.DocumentEnd

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/DocumentStartToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/DocumentStartToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class DocumentStartToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.DocumentStart

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/FlowEntryToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/FlowEntryToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class FlowEntryToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.FlowEntry

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/FlowMappingEndToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/FlowMappingEndToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class FlowMappingEndToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.FlowMappingEnd

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/FlowMappingStartToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/FlowMappingStartToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class FlowMappingStartToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.FlowMappingStart

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/FlowSequenceEndToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/FlowSequenceEndToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class FlowSequenceEndToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.FlowSequenceEnd

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/FlowSequenceStartToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/FlowSequenceStartToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class FlowSequenceStartToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.FlowSequenceStart

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/KeyToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/KeyToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class KeyToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.Key

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/ScalarToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/ScalarToken.kt
@@ -15,14 +15,12 @@ package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.common.ScalarStyle
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
-class ScalarToken @JvmOverloads
-constructor(
+class ScalarToken @JvmOverloads constructor(
     val value: String,
     val plain: Boolean,
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
     val style: ScalarStyle = ScalarStyle.PLAIN,
 ) : Token(startMark, endMark) {
 

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/StreamEndToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/StreamEndToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class StreamEndToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.StreamEnd

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/StreamStartToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/StreamStartToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class StreamStartToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.StreamStart

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/TagToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/TagToken.kt
@@ -14,12 +14,11 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class TagToken(
     val value: TagTuple,
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.Tag

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/TagTuple.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/TagTuple.kt
@@ -13,9 +13,7 @@
  */
 package org.snakeyaml.engine.v2.tokens
 
-import java.util.Optional
-
 class TagTuple(
-    val handle: Optional<String>,
+    val handle: String?,
     val suffix: String,
 )

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/Token.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/Token.kt
@@ -14,14 +14,13 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 /**
  * A unit of YAML data
  */
 sealed class Token(
-    val startMark: Optional<Mark>,
-    val endMark: Optional<Mark>,
+    val startMark: Mark?,
+    val endMark: Mark?,
 ) {
 
     /**

--- a/src/main/java/org/snakeyaml/engine/v2/tokens/ValueToken.kt
+++ b/src/main/java/org/snakeyaml/engine/v2/tokens/ValueToken.kt
@@ -14,11 +14,10 @@
 package org.snakeyaml.engine.v2.tokens
 
 import org.snakeyaml.engine.v2.exceptions.Mark
-import java.util.Optional
 
 class ValueToken(
-    startMark: Optional<Mark>,
-    endMark: Optional<Mark>,
+    startMark: Mark?,
+    endMark: Mark?,
 ) : Token(startMark, endMark) {
     override val tokenId: ID
         get() = ID.Value

--- a/src/test/java/org/snakeyaml/engine/issues/issue23/EmptyStringOutputTest.java
+++ b/src/test/java/org/snakeyaml/engine/issues/issue23/EmptyStringOutputTest.java
@@ -13,11 +13,6 @@
  */
 package org.snakeyaml.engine.issues.issue23;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.Dump;
 import org.snakeyaml.engine.v2.api.DumpSettings;
@@ -28,6 +23,11 @@ import org.snakeyaml.engine.v2.events.DocumentStartEvent;
 import org.snakeyaml.engine.v2.events.ImplicitTuple;
 import org.snakeyaml.engine.v2.events.ScalarEvent;
 import org.snakeyaml.engine.v2.events.StreamStartEvent;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @org.junit.jupiter.api.Tag("fast")
 public class EmptyStringOutputTest {
@@ -61,9 +61,9 @@ public class EmptyStringOutputTest {
     MyWriter writer = new MyWriter();
     Emitter emitter = new Emitter(settings, writer);
     emitter.emit(new StreamStartEvent());
-    emitter.emit(new DocumentStartEvent(false, Optional.empty(), new HashMap<>()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.empty(), new ImplicitTuple(true, false),
-        value, ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
+    emitter.emit(new DocumentStartEvent(false, null, new HashMap<>()));
+    emitter.emit(new ScalarEvent(null, null, new ImplicitTuple(true, false),
+        value, ScalarStyle.PLAIN, null, null));
     return writer.toString();
   }
 }

--- a/src/test/java/org/snakeyaml/engine/issues/issue36/EmitCommentTest.java
+++ b/src/test/java/org/snakeyaml/engine/issues/issue36/EmitCommentTest.java
@@ -13,11 +13,6 @@
  */
 package org.snakeyaml.engine.issues.issue36;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.DumpSettings;
@@ -25,13 +20,12 @@ import org.snakeyaml.engine.v2.api.StreamDataWriter;
 import org.snakeyaml.engine.v2.comments.CommentType;
 import org.snakeyaml.engine.v2.common.ScalarStyle;
 import org.snakeyaml.engine.v2.emitter.Emitter;
-import org.snakeyaml.engine.v2.events.CommentEvent;
-import org.snakeyaml.engine.v2.events.DocumentEndEvent;
-import org.snakeyaml.engine.v2.events.DocumentStartEvent;
-import org.snakeyaml.engine.v2.events.ImplicitTuple;
-import org.snakeyaml.engine.v2.events.ScalarEvent;
-import org.snakeyaml.engine.v2.events.StreamEndEvent;
-import org.snakeyaml.engine.v2.events.StreamStartEvent;
+import org.snakeyaml.engine.v2.events.*;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @org.junit.jupiter.api.Tag("fast")
 public class EmitCommentTest {
@@ -43,10 +37,10 @@ public class EmitCommentTest {
     StreamDataWriter writer = new StreamToStringWriter();
     Emitter emitter = new Emitter(settings, writer);
     emitter.emit(new StreamStartEvent());
-    emitter.emit(new DocumentStartEvent(false, Optional.empty(), new HashMap<>()));
+    emitter.emit(new DocumentStartEvent(false, null, new HashMap<>()));
     emitter.emit(
-        new CommentEvent(CommentType.BLOCK, "Hello world!", Optional.empty(), Optional.empty()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.empty(), new ImplicitTuple(true, true),
+        new CommentEvent(CommentType.BLOCK, "Hello world!", null, null));
+    emitter.emit(new ScalarEvent(null, null, new ImplicitTuple(true, true),
         "This is the scalar", ScalarStyle.DOUBLE_QUOTED));
     emitter.emit(new DocumentEndEvent(false));
     emitter.emit(new StreamEndEvent());
@@ -61,9 +55,9 @@ public class EmitCommentTest {
     StreamDataWriter writer = new StreamToStringWriter();
     Emitter emitter = new Emitter(settings, writer);
     emitter.emit(new StreamStartEvent());
-    emitter.emit(new DocumentStartEvent(false, Optional.empty(), new HashMap<>()));
+    emitter.emit(new DocumentStartEvent(false, null, new HashMap<>()));
     emitter.emit(
-        new CommentEvent(CommentType.BLOCK, "Hello world!", Optional.empty(), Optional.empty()));
+        new CommentEvent(CommentType.BLOCK, "Hello world!", null, null));
     emitter.emit(new DocumentEndEvent(false));
     emitter.emit(new StreamEndEvent());
 

--- a/src/test/java/org/snakeyaml/engine/usecases/binary/BinaryRoundTripTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/binary/BinaryRoundTripTest.java
@@ -13,14 +13,6 @@
  */
 package org.snakeyaml.engine.usecases.binary;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.Dump;
 import org.snakeyaml.engine.v2.api.DumpSettings;
@@ -37,6 +29,15 @@ import org.snakeyaml.engine.v2.nodes.NodeType;
 import org.snakeyaml.engine.v2.nodes.ScalarNode;
 import org.snakeyaml.engine.v2.nodes.Tag;
 import org.snakeyaml.engine.v2.representer.StandardRepresenter;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @org.junit.jupiter.api.Tag("fast")
 public class BinaryRoundTripTest {
@@ -70,7 +71,7 @@ public class BinaryRoundTripTest {
     List<Event> events = ((List<Event>) eventsIter).subList(0, ((List<Event>) eventsIter).size());
     assertEquals(5, events.size());
     ScalarEvent data = (ScalarEvent) events.get(2);
-    assertEquals(Tag.BINARY.toString(), data.getTag().get());
+    assertEquals(Tag.BINARY.toString(), data.getTag());
     assertEquals(ScalarStyle.LITERAL, data.getScalarStyle());
     assertEquals("wpY=", data.getValue());
     ImplicitTuple implicit = data.getImplicit();

--- a/src/test/java/org/snakeyaml/engine/usecases/env/CustomEnvConfig.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/env/CustomEnvConfig.java
@@ -13,18 +13,17 @@
  */
 package org.snakeyaml.engine.usecases.env;
 
-import java.util.Map;
-import java.util.Optional;
-
 import org.jetbrains.annotations.NotNull;
 import org.snakeyaml.engine.v2.env.EnvConfig;
+
+import java.util.Map;
 
 /**
  * Configurator for ENV format
  *
  * @see <a href=
- *      "https://bitbucket.org/snakeyaml/snakeyaml-engine/wiki/Documentation#markdown-header-variable-substitution">Variable
- *      substitution</a>
+ * "https://bitbucket.org/snakeyaml/snakeyaml-engine/wiki/Documentation#markdown-header-variable-substitution">Variable
+ * substitution</a>
  */
 public class CustomEnvConfig implements EnvConfig {
 
@@ -38,23 +37,23 @@ public class CustomEnvConfig implements EnvConfig {
    * Implement deviation from the standard logic. It chooses the value from the provided map, if not
    * found than check the system property, if not found than follow the standard logic.
    *
-   * @param name - variable name in the template
-   * @param separator - separator in the template, can be :-, -, :?, ? or null if not present
-   * @param value - default value or the error in the template or empty if not present
+   * @param name        - variable name in the template
+   * @param separator   - separator in the template, can be :-, -, :?, ? or null if not present
+   * @param value       - default value or the error in the template or empty if not present
    * @param environment - the value from environment for the provided variable or null if unset
    * @return the value to apply in the template or empty to follow the standard logic
    */
   @NotNull
-  public Optional<String> getValueFor(@NotNull String name,
-                                      String separator,
-                                      String value,
-                                      String environment) {
+  public String getValueFor(@NotNull String name,
+                            String separator,
+                            String value,
+                            String environment) {
     if (provided.containsKey(name)) {
-      return Optional.of(provided.get(name));
+      return provided.get(name);
     } else if (System.getProperty(name) != null) {
-      return Optional.of(System.getProperty(name));
+      return System.getProperty(name);
     } else {
-      return Optional.empty();
+      return null;
     }
   }
 }

--- a/src/test/java/org/snakeyaml/engine/usecases/env/EnvTagTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/env/EnvTagTest.java
@@ -13,14 +13,13 @@
  */
 package org.snakeyaml.engine.usecases.env;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.api.lowlevel.Compose;
 import org.snakeyaml.engine.v2.nodes.Node;
 import org.snakeyaml.engine.v2.nodes.Tag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * test that implicit resolver assigns the tag
@@ -30,7 +29,7 @@ public class EnvTagTest {
   @Test
   public void testImplicitResolverForEnvConstructor() {
     Compose loader = new Compose(LoadSettings.builder().build());
-    Optional<Node> loaded = loader.composeString("${PATH}");
-    assertEquals(Tag.ENV_TAG, loaded.get().getTag());
+    Node loaded = loader.composeString("${PATH}");
+    assertEquals(Tag.ENV_TAG, loaded.getTag());
   }
 }

--- a/src/test/java/org/snakeyaml/engine/usecases/env/EnvVariableTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/env/EnvVariableTest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,12 +39,13 @@ class EnvVariableTest {
   @DisplayName("Parse docker-compose.yaml example")
   public void testDockerCompose() {
     Load loader =
-        new Load(LoadSettings.builder().setEnvConfig(Optional.of(new EnvConfig() {})).build());
+        new Load(LoadSettings.builder().setEnvConfig(new EnvConfig() {
+        }).build());
     String resource = TestUtils.getResource("/env/docker-compose.yaml");
     Map<String, Object> compose = (Map<String, Object>) loader.loadFromString(resource);
     String output = compose.toString();
     assertTrue(output.endsWith(
-        "environment={URL1=EnvironmentValue1, URL2=, URL3=server3, URL4=, URL5=server5, URL6=server6}}}}"),
+            "environment={URL1=EnvironmentValue1, URL2=, URL3=server3, URL4=, URL5=server5, URL6=server6}}}}"),
         output);
   }
 
@@ -56,18 +56,19 @@ class EnvVariableTest {
     provided.put(KEY1, "VVVAAA111");
     System.setProperty(EMPTY, "VVVAAA222");
     Load loader = new Load(
-        LoadSettings.builder().setEnvConfig(Optional.of(new CustomEnvConfig(provided))).build());
+        LoadSettings.builder().setEnvConfig(new CustomEnvConfig(provided)).build());
     String resource = TestUtils.getResource("/env/docker-compose.yaml");
     Map<String, Object> compose = (Map<String, Object>) loader.loadFromString(resource);
     String output = compose.toString();
     assertTrue(output.endsWith(
-        "environment={URL1=VVVAAA111, URL2=VVVAAA222, URL3=VVVAAA222, URL4=VVVAAA222, URL5=server5, URL6=server6}}}}"),
+            "environment={URL1=VVVAAA111, URL2=VVVAAA222, URL3=VVVAAA222, URL4=VVVAAA222, URL5=server5, URL6=server6}}}}"),
         output);
   }
 
   private String load(String template) {
     Load loader =
-        new Load(LoadSettings.builder().setEnvConfig(Optional.of(new EnvConfig() {})).build());
+        new Load(LoadSettings.builder().setEnvConfig((new EnvConfig() {
+        })).build());
     return (String) loader.loadFromString(template);
   }
 

--- a/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/ComposeSuiteTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/ComposeSuiteTest.java
@@ -13,15 +13,7 @@
  */
 package org.snakeyaml.engine.usecases.external_test_suite;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.google.common.collect.Lists;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.DumpSettings;
@@ -31,6 +23,12 @@ import org.snakeyaml.engine.v2.api.lowlevel.Serialize;
 import org.snakeyaml.engine.v2.events.Event;
 import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
 import org.snakeyaml.engine.v2.nodes.Node;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @org.junit.jupiter.api.Tag("fast")
 class ComposeSuiteTest {
@@ -52,14 +50,14 @@ class ComposeSuiteTest {
 
 
   public static ComposeResult composeData(SuiteData data) {
-    Optional<Exception> error = Optional.empty();
+    Exception error = null;
     List<Node> list = new ArrayList();
     try {
       LoadSettings settings = LoadSettings.builder().setLabel(data.getLabel()).build();
       Iterable<Node> iterable = new Compose(settings).composeAllFromString(data.getInput());
       iterable.forEach(event -> list.add(event));
     } catch (YamlEngineException e) {
-      error = Optional.of(e);
+      error = e;
     }
     return new ComposeResult(list, error);
   }
@@ -69,8 +67,8 @@ class ComposeSuiteTest {
   void runOne() {
     SuiteData data = SuiteUtils.getOne("C4HZ");
     LoadSettings settings = LoadSettings.builder().setLabel(data.getLabel()).build();
-    Optional<Node> node = new Compose(settings).composeString(data.getInput());
-    assertTrue(node.isPresent());
+    Node node = new Compose(settings).composeString(data.getInput());
+    assertNotNull(node);
     // System.out.println(node);
   }
 
@@ -136,9 +134,9 @@ class ComposeSuiteTest {
 class ComposeResult {
 
   private final List<Node> node;
-  private final Optional<Exception> error;
+  private final Exception error;
 
-  public ComposeResult(List<Node> node, Optional<Exception> error) {
+  public ComposeResult(List<Node> node, Exception error) {
     this.node = node;
     this.error = error;
   }
@@ -147,8 +145,7 @@ class ComposeResult {
     return node;
   }
 
-  public Optional<Exception> getError() {
+  public Exception getError() {
     return error;
   }
 }
-

--- a/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/EmitSuiteTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/EmitSuiteTest.java
@@ -13,16 +13,17 @@
  */
 package org.snakeyaml.engine.usecases.external_test_suite;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.api.lowlevel.Compose;
 import org.snakeyaml.engine.v2.api.lowlevel.Present;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @org.junit.jupiter.api.Tag("fast")
 class EmitSuiteTest {
@@ -38,7 +39,7 @@ class EmitSuiteTest {
     for (SuiteData data : all) {
       ParseResult result = SuiteUtils.parseData(data);
       if (data.hasError()) {
-        assertTrue(result.getError().isPresent(), "Expected error, but got none in file "
+        assertNotNull(result.getError(), "Expected error, but got none in file "
             + data.getName() + ", " + data.getLabel() + "\n" + result.getEvents());
       } else {
         Present emit = new Present(DumpSettings.builder().build());
@@ -50,4 +51,3 @@ class EmitSuiteTest {
     }
   }
 }
-

--- a/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/EventRepresentation.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/EventRepresentation.java
@@ -14,17 +14,11 @@
 package org.snakeyaml.engine.usecases.external_test_suite;
 
 import com.google.common.base.Splitter;
-import java.util.List;
 import org.snakeyaml.engine.v2.common.FlowStyle;
-import org.snakeyaml.engine.v2.events.AliasEvent;
-import org.snakeyaml.engine.v2.events.CollectionStartEvent;
-import org.snakeyaml.engine.v2.events.Event;
-import org.snakeyaml.engine.v2.events.ImplicitTuple;
-import org.snakeyaml.engine.v2.events.MappingStartEvent;
-import org.snakeyaml.engine.v2.events.NodeEvent;
-import org.snakeyaml.engine.v2.events.ScalarEvent;
-import org.snakeyaml.engine.v2.events.SequenceStartEvent;
+import org.snakeyaml.engine.v2.events.*;
 import org.snakeyaml.engine.v2.nodes.Tag;
+
+import java.util.List;
 
 /**
  * Event representation for the external test suite
@@ -56,27 +50,27 @@ public class EventRepresentation {
      */
     if (event instanceof MappingStartEvent) {
       CollectionStartEvent e = (CollectionStartEvent) event;
-      boolean tagIsPresent = e.getTag().isPresent();
+      boolean tagIsPresent = e.getTag() != null;
       String mapTag = Tag.MAP.getValue();
-      if (tagIsPresent && !mapTag.equals(e.getTag().get())) {
+      if (tagIsPresent && !mapTag.equals(e.getTag())) {
         String last = split.get(split.size() - 1);
-        if (!last.equals("<" + e.getTag().get() + ">")) {
+        if (!last.equals("<" + e.getTag() + ">")) {
           return false;
         }
       }
     }
     if (event instanceof SequenceStartEvent) {
       SequenceStartEvent e = (SequenceStartEvent) event;
-      if (e.getTag().isPresent() && !Tag.SEQ.getValue().equals(e.getTag().get())) {
+      if (e.getTag() != null && !Tag.SEQ.getValue().equals(e.getTag())) {
         String last = split.get(split.size() - 1);
-        if (!last.equals("<" + e.getTag().get() + ">")) {
+        if (!last.equals("<" + e.getTag() + ">")) {
           return false;
         }
       }
     }
     if (event instanceof NodeEvent) {
       NodeEvent e = (NodeEvent) event;
-      if (e.getAnchor().isPresent()) {
+      if (e.getAnchor() != null) {
         int indexOfAlias = 1;
         if (event.getEventId().equals(Event.ID.SequenceStart)
             || event.getEventId().equals(Event.ID.MappingStart)) {
@@ -98,11 +92,11 @@ public class EventRepresentation {
     }
     if (event instanceof ScalarEvent) {
       ScalarEvent e = (ScalarEvent) event;
-      if (e.getTag().isPresent()) {
-        String tag = e.getTag().get();
+      if (e.getTag() != null) {
+        String tag = e.getTag();
         ImplicitTuple implicit = e.getImplicit();
         if (implicit.bothFalse()) {
-          if (!data.contains("<" + e.getTag().get() + ">")) {
+          if (!data.contains("<" + e.getTag() + ">")) {
             return false;
           }
         }

--- a/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/EventRepresentationTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/EventRepresentationTest.java
@@ -13,27 +13,17 @@
  */
 package org.snakeyaml.engine.usecases.external_test_suite;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Collections;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.common.Anchor;
 import org.snakeyaml.engine.v2.common.FlowStyle;
 import org.snakeyaml.engine.v2.common.ScalarStyle;
-import org.snakeyaml.engine.v2.events.AliasEvent;
-import org.snakeyaml.engine.v2.events.DocumentEndEvent;
-import org.snakeyaml.engine.v2.events.DocumentStartEvent;
-import org.snakeyaml.engine.v2.events.Event;
-import org.snakeyaml.engine.v2.events.ImplicitTuple;
-import org.snakeyaml.engine.v2.events.MappingStartEvent;
-import org.snakeyaml.engine.v2.events.ScalarEvent;
-import org.snakeyaml.engine.v2.events.SequenceEndEvent;
-import org.snakeyaml.engine.v2.events.SequenceStartEvent;
-import org.snakeyaml.engine.v2.events.StreamEndEvent;
-import org.snakeyaml.engine.v2.events.StreamStartEvent;
+import org.snakeyaml.engine.v2.events.*;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @org.junit.jupiter.api.Tag("fast")
 class EventRepresentationTest {
@@ -60,7 +50,7 @@ class EventRepresentationTest {
   @Test
   @DisplayName("Represent AliasEvent")
   void testAliasEvent() {
-    AliasEvent event = new AliasEvent(Optional.of(new Anchor("a")));
+    AliasEvent event = new AliasEvent(new Anchor("a"));
     EventRepresentation representation = new EventRepresentation(event);
     assertTrue(representation.isSameAs("=ALI *a"));
     assertTrue(representation.isSameAs("=ALI *b"));
@@ -72,11 +62,11 @@ class EventRepresentationTest {
   @Test
   @DisplayName("Represent DocumentStartEvent")
   void testDocumentStartEvent() {
-    valid(new DocumentStartEvent(true, Optional.empty(), Collections.emptyMap()), "+DOC ---");
-    valid(new DocumentStartEvent(true, Optional.empty(), Collections.emptyMap()), "+DOC");
+    valid(new DocumentStartEvent(true, null, Collections.emptyMap()), "+DOC ---");
+    valid(new DocumentStartEvent(true, null, Collections.emptyMap()), "+DOC");
 
-    valid(new DocumentStartEvent(false, Optional.empty(), Collections.emptyMap()), "+DOC");
-    valid(new DocumentStartEvent(false, Optional.empty(), Collections.emptyMap()), "+DOC ---");
+    valid(new DocumentStartEvent(false, null, Collections.emptyMap()), "+DOC");
+    valid(new DocumentStartEvent(false, null, Collections.emptyMap()), "+DOC ---");
   }
 
   @Test
@@ -90,17 +80,17 @@ class EventRepresentationTest {
   @Test
   @DisplayName("Represent SequenceStartEvent")
   void testSequenceStartEvent() {
-    valid(new SequenceStartEvent(Optional.of(new Anchor("a")), Optional.of("ttt"), false,
+    valid(new SequenceStartEvent(new Anchor("a"), "ttt", false,
         FlowStyle.FLOW), "+SEQ [] &a <ttt>");
-    valid(new SequenceStartEvent(Optional.of(new Anchor("a")), Optional.of("ttt"), false,
+    valid(new SequenceStartEvent(new Anchor("a"), "ttt", false,
         FlowStyle.BLOCK), "+SEQ &a <ttt>");
-    invalid(new SequenceStartEvent(Optional.of(new Anchor("a")), Optional.of("ttt"), false,
+    invalid(new SequenceStartEvent(new Anchor("a"), "ttt", false,
         FlowStyle.BLOCK), "+SEQ *a <ttt>");
-    invalid(new SequenceStartEvent(Optional.of(new Anchor("a")), Optional.of("ttt"), false,
+    invalid(new SequenceStartEvent(new Anchor("a"), "ttt", false,
         FlowStyle.BLOCK), "+SEQ &a <t>");
-    invalid(new SequenceStartEvent(Optional.of(new Anchor("a")), Optional.of("ttt"), false,
+    invalid(new SequenceStartEvent(new Anchor("a"), "ttt", false,
         FlowStyle.BLOCK), "+SEQ <ttt>");
-    invalid(new SequenceStartEvent(Optional.of(new Anchor("a")), Optional.of("ttt"), false,
+    invalid(new SequenceStartEvent(new Anchor("a"), "ttt", false,
         FlowStyle.BLOCK), "+SEQ *a");
   }
 
@@ -114,29 +104,29 @@ class EventRepresentationTest {
   @Test
   @DisplayName("Represent ScalarEvent")
   void testScalarEvent() {
-    valid(new ScalarEvent(Optional.of(new Anchor("a")), Optional.of("ttt"),
+    valid(new ScalarEvent(new Anchor("a"), "ttt",
         new ImplicitTuple(false, false), "v1", ScalarStyle.FOLDED), "=VAL &a <ttt> >v1");
 
-    invalid(new ScalarEvent(Optional.of(new Anchor("a")), Optional.of("ttt"),
+    invalid(new ScalarEvent(new Anchor("a"), "ttt",
         new ImplicitTuple(false, false), "v1", ScalarStyle.PLAIN), "=VAL <ttt> >v1");
-    invalid(new ScalarEvent(Optional.of(new Anchor("a")), Optional.of("ttt"),
+    invalid(new ScalarEvent(new Anchor("a"), "ttt",
         new ImplicitTuple(false, false), "v1", ScalarStyle.PLAIN), "=VAL &a >v1");
-    invalid(new ScalarEvent(Optional.of(new Anchor("a")), Optional.of("ttt"),
+    invalid(new ScalarEvent(new Anchor("a"), "ttt",
         new ImplicitTuple(false, false), "v1", ScalarStyle.PLAIN), "=VAL &a <ttt>");
-    invalid(new ScalarEvent(Optional.of(new Anchor("a")), Optional.of("ttt"),
+    invalid(new ScalarEvent(new Anchor("a"), ("ttt"),
         new ImplicitTuple(false, false), "v1", ScalarStyle.PLAIN), "=VAL &a <ttt> |v1");
   }
 
   @Test
   @DisplayName("Represent MappingStartEvent")
   void testMappingStartEvent() {
-    invalid(new MappingStartEvent(Optional.of(new Anchor("a")), Optional.of("ttt"), false,
+    invalid(new MappingStartEvent((new Anchor("a")), ("ttt"), false,
         FlowStyle.FLOW), "+MAP");
     valid(
-        new MappingStartEvent(Optional.empty(),
-            Optional.of(org.snakeyaml.engine.v2.nodes.Tag.MAP.getValue()), false, FlowStyle.FLOW),
+        new MappingStartEvent(null,
+            org.snakeyaml.engine.v2.nodes.Tag.MAP.getValue(), false, FlowStyle.FLOW),
         "+MAP");
-    valid(new MappingStartEvent(Optional.empty(), Optional.empty(), false, FlowStyle.FLOW), "+MAP");
+    valid(new MappingStartEvent(null, null, false, FlowStyle.FLOW), "+MAP");
   }
 
   private void valid(Event event, String expectation) {

--- a/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/ParseSuiteTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/ParseSuiteTest.java
@@ -13,19 +13,17 @@
  */
 package org.snakeyaml.engine.usecases.external_test_suite;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import com.google.common.collect.Streams;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.api.lowlevel.Parse;
 import org.snakeyaml.engine.v2.events.Event;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @org.junit.jupiter.api.Tag("fast")
 class ParseSuiteTest {
@@ -61,12 +59,12 @@ class ParseSuiteTest {
         shouldFail = !shouldFail;
       }
       if (shouldFail) {
-        assertTrue(result.getError().isPresent(), "Expected error, but got none in file "
+        assertNotNull(result.getError(), "Expected error, but got none in file "
             + data.getName() + ", " + data.getLabel() + "\n" + result.getEvents());
       } else {
-        if (result.getError().isPresent()) {
+        if (result.getError() != null) {
           fail("Testcase: " + data.getName() + "; label: " + data.getLabel()
-              + "\nExpected NO error, but got: " + result.getError().get());
+              + "\nExpected NO error, but got: " + result.getError());
         } else {
           List<ParsePair> pairs =
               Streams.zip(data.getEvents().stream(), result.getEvents().stream(), ParsePair::new)

--- a/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/SuiteUtils.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/SuiteUtils.java
@@ -16,17 +16,17 @@ package org.snakeyaml.engine.usecases.external_test_suite;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.api.lowlevel.Parse;
+import org.snakeyaml.engine.v2.events.Event;
+import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
-import org.snakeyaml.engine.v2.api.LoadSettings;
-import org.snakeyaml.engine.v2.api.lowlevel.Parse;
-import org.snakeyaml.engine.v2.events.Event;
-import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
 
 public class SuiteUtils {
 
@@ -78,14 +78,14 @@ public class SuiteUtils {
   }
 
   public static ParseResult parseData(SuiteData data) {
-    Optional<Exception> error = Optional.empty();
+    Exception error = null;
     List<Event> list = new ArrayList();
     try {
       LoadSettings settings = LoadSettings.builder().setLabel(data.getLabel()).build();
       Iterable<Event> iterable = new Parse(settings).parseString(data.getInput());
       iterable.forEach(event -> list.add(event));
     } catch (YamlEngineException e) {
-      error = Optional.of(e);
+      error = e;
     }
     return new ParseResult(list, error);
   }
@@ -95,9 +95,9 @@ public class SuiteUtils {
 class ParseResult {
 
   private final List<Event> events;
-  private final Optional<Exception> error;
+  private final Exception error;
 
-  public ParseResult(List<Event> events, Optional<Exception> error) {
+  public ParseResult(List<Event> events, Exception error) {
     this.events = events;
     this.error = error;
   }
@@ -106,7 +106,7 @@ class ParseResult {
     return events;
   }
 
-  public Optional<Exception> getError() {
+  public Exception getError() {
     return error;
   }
 }

--- a/src/test/java/org/snakeyaml/engine/usecases/inherited/CanonicalParser.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/inherited/CanonicalParser.java
@@ -13,35 +13,19 @@
  */
 package org.snakeyaml.engine.usecases.inherited;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-
 import org.jetbrains.annotations.NotNull;
 import org.snakeyaml.engine.v2.common.Anchor;
 import org.snakeyaml.engine.v2.common.FlowStyle;
 import org.snakeyaml.engine.v2.common.ScalarStyle;
 import org.snakeyaml.engine.v2.common.SpecVersion;
-import org.snakeyaml.engine.v2.events.AliasEvent;
-import org.snakeyaml.engine.v2.events.DocumentEndEvent;
-import org.snakeyaml.engine.v2.events.DocumentStartEvent;
-import org.snakeyaml.engine.v2.events.Event;
-import org.snakeyaml.engine.v2.events.ImplicitTuple;
-import org.snakeyaml.engine.v2.events.MappingEndEvent;
-import org.snakeyaml.engine.v2.events.MappingStartEvent;
-import org.snakeyaml.engine.v2.events.ScalarEvent;
-import org.snakeyaml.engine.v2.events.SequenceEndEvent;
-import org.snakeyaml.engine.v2.events.SequenceStartEvent;
-import org.snakeyaml.engine.v2.events.StreamEndEvent;
-import org.snakeyaml.engine.v2.events.StreamStartEvent;
+import org.snakeyaml.engine.v2.events.*;
 import org.snakeyaml.engine.v2.nodes.Tag;
 import org.snakeyaml.engine.v2.parser.Parser;
-import org.snakeyaml.engine.v2.tokens.AliasToken;
-import org.snakeyaml.engine.v2.tokens.AnchorToken;
-import org.snakeyaml.engine.v2.tokens.ScalarToken;
-import org.snakeyaml.engine.v2.tokens.TagToken;
-import org.snakeyaml.engine.v2.tokens.Token;
+import org.snakeyaml.engine.v2.tokens.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.NoSuchElementException;
 
 public class CanonicalParser implements Parser {
 
@@ -58,7 +42,7 @@ public class CanonicalParser implements Parser {
   // stream: STREAM-START document* STREAM-END
   private void parseStream() {
     scanner.getToken(Token.ID.StreamStart);
-    events.add(new StreamStartEvent(Optional.empty(), Optional.empty()));
+    events.add(new StreamStartEvent(null, null));
     while (!scanner.checkToken(Token.ID.StreamEnd)) {
       if (scanner.checkToken(Token.ID.Directive, Token.ID.DocumentStart)) {
         parseDocument();
@@ -68,7 +52,7 @@ public class CanonicalParser implements Parser {
       }
     }
     scanner.getToken(Token.ID.StreamEnd);
-    events.add(new StreamEndEvent(Optional.empty(), Optional.empty()));
+    events.add(new StreamEndEvent(null, null));
   }
 
   // document: DIRECTIVE? DOCUMENT-START node
@@ -77,42 +61,42 @@ public class CanonicalParser implements Parser {
       scanner.getToken(Token.ID.Directive);
     }
     scanner.getToken(Token.ID.DocumentStart);
-    events.add(new DocumentStartEvent(true, Optional.of(new SpecVersion(1, 2)),
-        Collections.emptyMap(), Optional.empty(), Optional.empty()));
+    events.add(new DocumentStartEvent(true, new SpecVersion(1, 2),
+        Collections.emptyMap(), null, null));
     parseNode();
     if (scanner.checkToken(Token.ID.DocumentEnd)) {
       scanner.getToken(Token.ID.DocumentEnd);
     }
-    events.add(new DocumentEndEvent(true, Optional.empty(), Optional.empty()));
+    events.add(new DocumentEndEvent(true, null, null));
   }
 
   // node: ALIAS | ANCHOR? TAG? (SCALAR|sequence|mapping)
   private void parseNode() {
     if (scanner.checkToken(Token.ID.Alias)) {
       AliasToken token = (AliasToken) scanner.next();
-      events.add(new AliasEvent(Optional.of(token.getValue()), Optional.empty(), Optional.empty()));
+      events.add(new AliasEvent(token.getValue(), null, null));
     } else {
-      Optional<Anchor> anchor = Optional.empty();
+      Anchor anchor = null;
       if (scanner.checkToken(Token.ID.Anchor)) {
         AnchorToken token = (AnchorToken) scanner.next();
-        anchor = Optional.of(token.getValue());
+        anchor = token.getValue();
       }
-      Optional<String> tag = Optional.empty();
+      String tag = null;
       if (scanner.checkToken(Token.ID.Tag)) {
         TagToken token = (TagToken) scanner.next();
-        tag = Optional.of(token.getValue().getHandle() + token.getValue().getSuffix());
+        tag = token.getValue().getHandle() + token.getValue().getSuffix();
       }
       if (scanner.checkToken(Token.ID.Scalar)) {
         ScalarToken token = (ScalarToken) scanner.next();
         events.add(new ScalarEvent(anchor, tag, new ImplicitTuple(false, false), token.getValue(),
-            ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
+            ScalarStyle.PLAIN, null, null));
       } else if (scanner.checkToken(Token.ID.FlowSequenceStart)) {
-        events.add(new SequenceStartEvent(anchor, Optional.of(Tag.SEQ.getValue()), false,
-            FlowStyle.AUTO, Optional.empty(), Optional.empty()));
+        events.add(new SequenceStartEvent(anchor, Tag.SEQ.getValue(), false,
+            FlowStyle.AUTO, null, null));
         parseSequence();
       } else if (scanner.checkToken(Token.ID.FlowMappingStart)) {
-        events.add(new MappingStartEvent(anchor, Optional.of(Tag.MAP.getValue()), false,
-            FlowStyle.AUTO, Optional.empty(), Optional.empty()));
+        events.add(new MappingStartEvent(anchor, Tag.MAP.getValue(), false,
+            FlowStyle.AUTO, null, null));
         parseMapping();
       } else {
         throw new CanonicalException(
@@ -134,7 +118,7 @@ public class CanonicalParser implements Parser {
       }
     }
     scanner.getToken(Token.ID.FlowSequenceEnd);
-    events.add(new SequenceEndEvent(Optional.empty(), Optional.empty()));
+    events.add(new SequenceEndEvent(null, null));
   }
 
   // mapping: MAPPING-START (map_entry (ENTRY map_entry)*)? ENTRY? MAPPING-END
@@ -150,7 +134,7 @@ public class CanonicalParser implements Parser {
       }
     }
     scanner.getToken(Token.ID.FlowMappingEnd);
-    events.add(new MappingEndEvent(Optional.empty(), Optional.empty()));
+    events.add(new MappingEndEvent(null, null));
   }
 
   // map_entry: KEY node VALUE node

--- a/src/test/java/org/snakeyaml/engine/usecases/inherited/CanonicalScanner.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/inherited/CanonicalScanner.java
@@ -13,33 +13,15 @@
  */
 package org.snakeyaml.engine.usecases.inherited;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.snakeyaml.engine.v2.common.Anchor;
 import org.snakeyaml.engine.v2.exceptions.Mark;
 import org.snakeyaml.engine.v2.nodes.Tag;
 import org.snakeyaml.engine.v2.scanner.Scanner;
-import org.snakeyaml.engine.v2.tokens.AliasToken;
-import org.snakeyaml.engine.v2.tokens.AnchorToken;
-import org.snakeyaml.engine.v2.tokens.DirectiveToken;
-import org.snakeyaml.engine.v2.tokens.DocumentEndToken;
-import org.snakeyaml.engine.v2.tokens.DocumentStartToken;
-import org.snakeyaml.engine.v2.tokens.FlowEntryToken;
-import org.snakeyaml.engine.v2.tokens.FlowMappingEndToken;
-import org.snakeyaml.engine.v2.tokens.FlowMappingStartToken;
-import org.snakeyaml.engine.v2.tokens.FlowSequenceEndToken;
-import org.snakeyaml.engine.v2.tokens.FlowSequenceStartToken;
-import org.snakeyaml.engine.v2.tokens.KeyToken;
-import org.snakeyaml.engine.v2.tokens.ScalarToken;
-import org.snakeyaml.engine.v2.tokens.StreamEndToken;
-import org.snakeyaml.engine.v2.tokens.StreamStartToken;
-import org.snakeyaml.engine.v2.tokens.TagToken;
-import org.snakeyaml.engine.v2.tokens.TagTuple;
-import org.snakeyaml.engine.v2.tokens.Token;
-import org.snakeyaml.engine.v2.tokens.ValueToken;
+import org.snakeyaml.engine.v2.tokens.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class CanonicalScanner implements Scanner {
 
@@ -91,7 +73,7 @@ public class CanonicalScanner implements Scanner {
 
   private final String data;
   private final String label;
-  private final Optional<Mark> mark;
+  private final Mark mark;
   public ArrayList<Token> tokens;
   private int index;
   private boolean scanned;
@@ -100,9 +82,9 @@ public class CanonicalScanner implements Scanner {
     this.data = data + "\0";
     this.label = label;
     this.index = 0;
-    this.tokens = new ArrayList<Token>();
+    this.tokens = new ArrayList<>();
     this.scanned = false;
-    this.mark = Optional.of(new Mark("test", 0, 0, 0, data.toCharArray(), 0));
+    this.mark = new Mark("test", 0, 0, 0, data.toCharArray(), 0);
   }
 
   public boolean checkToken(Token.ID... choices) {
@@ -294,7 +276,7 @@ public class CanonicalScanner implements Scanner {
     } else {
       value = "!" + value;
     }
-    return new TagToken(new TagTuple(Optional.of(""), value), mark, mark);
+    return new TagToken(new TagTuple("", value), mark, mark);
   }
 
   private Token scanScalar() {

--- a/src/test/java/org/snakeyaml/engine/usecases/references/DumpAnchorTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/references/DumpAnchorTest.java
@@ -14,21 +14,20 @@
 package org.snakeyaml.engine.usecases.references;
 
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.StringReader;
-import java.io.StringWriter;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.Dump;
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.api.StreamDataWriter;
 import org.snakeyaml.engine.v2.api.lowlevel.Compose;
-import org.snakeyaml.engine.v2.common.Anchor;
 import org.snakeyaml.engine.v2.common.FlowStyle;
 import org.snakeyaml.engine.v2.nodes.Node;
-import org.snakeyaml.engine.v2.serializer.AnchorGenerator;
 import org.snakeyaml.engine.v2.utils.TestUtils;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @org.junit.jupiter.api.Tag("fast")
 public class DumpAnchorTest {
@@ -37,10 +36,10 @@ public class DumpAnchorTest {
   public void test_anchor_test() {
     String str = TestUtils.getResource("/anchor/issue481.yaml");
     Compose compose = new Compose(LoadSettings.builder().build());
-    Node node = compose.composeReader(new StringReader(str)).get();
+    Node node = compose.composeReader(new StringReader(str));
 
     DumpSettings setting = DumpSettings.builder().setDefaultFlowStyle(FlowStyle.BLOCK)
-        .setAnchorGenerator(node1 -> node1.getAnchor().get()).build();
+        .setAnchorGenerator(node1 -> node1.getAnchor()).build();
     Dump yaml = new Dump(setting);
 
     StreamDataWriter writer = new MyDumperWriter();

--- a/src/test/java/org/snakeyaml/engine/usecases/tags/ExplicitRootTagTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/tags/ExplicitRootTagTest.java
@@ -13,15 +13,15 @@
  */
 package org.snakeyaml.engine.usecases.tags;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.Dump;
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.nodes.Tag;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Example of serializing a root tag
@@ -32,7 +32,7 @@ public class ExplicitRootTagTest {
   @Test
   public void testLocalTag() {
     DumpSettings settings =
-        DumpSettings.builder().setExplicitRootTag(Optional.of(new Tag("!my-data"))).build();
+        DumpSettings.builder().setExplicitRootTag(new Tag("!my-data")).build();
     Map<String, String> map = new HashMap();
     map.put("foo", "bar");
     Dump dump = new Dump(settings);

--- a/src/test/java/org/snakeyaml/engine/v2/api/OptionalMarksTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/api/OptionalMarksTest.java
@@ -13,11 +13,6 @@
  */
 package org.snakeyaml.engine.v2.api;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -26,6 +21,8 @@ import org.snakeyaml.engine.usecases.external_test_suite.SuiteUtils;
 import org.snakeyaml.engine.v2.api.lowlevel.Compose;
 import org.snakeyaml.engine.v2.exceptions.ParserException;
 import org.snakeyaml.engine.v2.nodes.Node;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("fast")
 class OptionalMarksTest {
@@ -36,8 +33,8 @@ class OptionalMarksTest {
     SuiteData data = SuiteUtils.getOne("2AUY");
     LoadSettings settings =
         LoadSettings.builder().setLabel(data.getLabel()).setUseMarks(false).build();
-    Optional<Node> node = new Compose(settings).composeString("{a: 4}");
-    assertTrue(node.isPresent());
+    Node node = new Compose(settings).composeString("{a: 4}");
+    assertNotNull(node);
   }
 
   @Test
@@ -64,4 +61,3 @@ class OptionalMarksTest {
     assertEquals("expected '<document start>', but found '}'\n", exception.getMessage());
   }
 }
-

--- a/src/test/java/org/snakeyaml/engine/v2/api/dump/DumpSettingsTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/api/dump/DumpSettingsTest.java
@@ -13,20 +13,6 @@
  */
 package org.snakeyaml.engine.v2.api.dump;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.TreeMap;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -38,6 +24,10 @@ import org.snakeyaml.engine.v2.common.NonPrintableStyle;
 import org.snakeyaml.engine.v2.common.ScalarStyle;
 import org.snakeyaml.engine.v2.common.SpecVersion;
 import org.snakeyaml.engine.v2.exceptions.EmitterException;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("fast")
 class DumpSettingsTest {
@@ -51,7 +41,7 @@ class DumpSettingsTest {
     assertEquals(2, settings.indent);
     assertEquals(FlowStyle.AUTO, settings.defaultFlowStyle);
     assertEquals(ScalarStyle.PLAIN, settings.defaultScalarStyle);
-    assertEquals(Optional.empty(), settings.explicitRootTag);
+    assertEquals(null, settings.explicitRootTag);
     assertFalse(settings.indentWithIndicator);
     assertFalse(settings.isExplicitEnd());
     assertFalse(settings.isExplicitStart());
@@ -63,7 +53,7 @@ class DumpSettingsTest {
     assertEquals(128, settings.maxSimpleKeyLength);
     assertEquals(NonPrintableStyle.ESCAPE, settings.nonPrintableStyle);
     assertEquals(80, settings.width);
-    assertEquals(Optional.empty(), settings.yamlDirective);
+    assertEquals(null, settings.yamlDirective);
     assertEquals(new HashMap<>(), settings.tagDirective);
     assertNotNull(settings.anchorGenerator);
   }
@@ -147,7 +137,7 @@ class DumpSettingsTest {
   @DisplayName("Dump explicit version")
   void dumpVersion() {
     DumpSettings settings =
-        DumpSettings.builder().setYamlDirective(Optional.of(new SpecVersion(1, 2))).build();
+        DumpSettings.builder().setYamlDirective(new SpecVersion(1, 2)).build();
     Dump dump = new Dump(settings);
     String str = dump.dumpToString("a");
     assertEquals("%YAML 1.2\n" + "--- a\n", str);

--- a/src/test/java/org/snakeyaml/engine/v2/api/lowlevel/ComposeTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/api/lowlevel/ComposeTest.java
@@ -13,17 +13,17 @@
  */
 package org.snakeyaml.engine.v2.api.lowlevel;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 import com.google.common.io.CharSource;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Optional;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.nodes.Node;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @Tag("fast")
 class ComposeTest {
@@ -31,15 +31,15 @@ class ComposeTest {
   @Test
   void composeEmptyReader() throws IOException {
     Compose compose = new Compose(LoadSettings.builder().build());
-    Optional<Node> node = compose.composeReader(CharSource.wrap("").openStream());
-    assertEquals(Optional.empty(), node);
+    Node node = compose.composeReader(CharSource.wrap("").openStream());
+    assertNull(node);
   }
 
   @Test
   void composeEmptyInputStream() {
     Compose compose = new Compose(LoadSettings.builder().build());
-    Optional<Node> node = compose.composeInputStream(new ByteArrayInputStream("".getBytes()));
-    assertEquals(Optional.empty(), node);
+    Node node = compose.composeInputStream(new ByteArrayInputStream("".getBytes()));
+    assertNull(node);
   }
 
   @Test
@@ -52,8 +52,7 @@ class ComposeTest {
   @Test
   void composeAllFromEmptyInputStream() {
     Compose compose = new Compose(LoadSettings.builder().build());
-    Iterable<Node> nodes =
-        compose.composeAllFromInputStream(new ByteArrayInputStream("".getBytes()));
+    Iterable<Node> nodes = compose.composeAllFromInputStream(new ByteArrayInputStream("".getBytes()));
     assertFalse(nodes.iterator().hasNext());
   }
 }

--- a/src/test/java/org/snakeyaml/engine/v2/api/lowlevel/SerializeTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/api/lowlevel/SerializeTest.java
@@ -13,25 +13,19 @@
  */
 package org.snakeyaml.engine.v2.api.lowlevel;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import com.google.common.collect.Lists;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.common.ScalarStyle;
-import org.snakeyaml.engine.v2.events.DocumentEndEvent;
-import org.snakeyaml.engine.v2.events.DocumentStartEvent;
-import org.snakeyaml.engine.v2.events.Event;
-import org.snakeyaml.engine.v2.events.ImplicitTuple;
-import org.snakeyaml.engine.v2.events.ScalarEvent;
-import org.snakeyaml.engine.v2.events.StreamEndEvent;
-import org.snakeyaml.engine.v2.events.StreamStartEvent;
+import org.snakeyaml.engine.v2.events.*;
 import org.snakeyaml.engine.v2.nodes.ScalarNode;
 import org.snakeyaml.engine.v2.nodes.Tag;
 import org.snakeyaml.engine.v2.utils.TestUtils;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @org.junit.jupiter.api.Tag("fast")
 class SerializeTest {
@@ -46,8 +40,8 @@ class SerializeTest {
     TestUtils
         .compareEvents(
             Lists.newArrayList(new StreamStartEvent(),
-                new DocumentStartEvent(false, Optional.empty(), new HashMap<>()),
-                new ScalarEvent(Optional.empty(), Optional.empty(), new ImplicitTuple(false, false),
+                new DocumentStartEvent(false, null, new HashMap<>()),
+                new ScalarEvent(null, null, new ImplicitTuple(false, false),
                     "a", ScalarStyle.PLAIN),
                 new DocumentEndEvent(false), new StreamEndEvent()),
             list);

--- a/src/test/java/org/snakeyaml/engine/v2/api/types/OptionalTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/api/types/OptionalTest.java
@@ -13,10 +13,7 @@
  */
 package org.snakeyaml.engine.v2.api.types;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import com.google.common.collect.Lists;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.Dump;
@@ -25,6 +22,10 @@ import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.nodes.Node;
 import org.snakeyaml.engine.v2.representer.StandardRepresenter;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @org.junit.jupiter.api.Tag("fast")
 class OptionalTest {
@@ -70,8 +71,11 @@ class OptionalTest {
   void dumpListOfOptional() {
     DumpSettings settings = DumpSettings.builder().build();
     Dump dump = new Dump(settings);
-    String str =
-        dump.dumpToString(Lists.newArrayList(Optional.of(2), Optional.empty(), Optional.of("a")));
+    String str = dump.dumpToString(Lists.newArrayList(
+        Optional.of(2),
+        Optional.empty(),
+        Optional.of("a"))
+    );
     assertEquals("[!!java.util.Optional '2', null, !!java.util.Optional 'a']\n", str);
   }
 

--- a/src/test/java/org/snakeyaml/engine/v2/comments/ComposerWithCommentEnabledTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/comments/ComposerWithCommentEnabledTest.java
@@ -13,8 +13,13 @@
  */
 package org.snakeyaml.engine.v2.comments;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.composer.Composer;
+import org.snakeyaml.engine.v2.constructor.StandardConstructor;
+import org.snakeyaml.engine.v2.nodes.*;
+import org.snakeyaml.engine.v2.parser.ParserImpl;
+import org.snakeyaml.engine.v2.scanner.StreamReader;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -22,17 +27,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import org.junit.jupiter.api.Test;
-import org.snakeyaml.engine.v2.api.LoadSettings;
-import org.snakeyaml.engine.v2.composer.Composer;
-import org.snakeyaml.engine.v2.constructor.StandardConstructor;
-import org.snakeyaml.engine.v2.nodes.MappingNode;
-import org.snakeyaml.engine.v2.nodes.Node;
-import org.snakeyaml.engine.v2.nodes.NodeTuple;
-import org.snakeyaml.engine.v2.nodes.ScalarNode;
-import org.snakeyaml.engine.v2.nodes.SequenceNode;
-import org.snakeyaml.engine.v2.parser.ParserImpl;
-import org.snakeyaml.engine.v2.scanner.StreamReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ComposerWithCommentEnabledTest {
 
@@ -166,7 +163,7 @@ public class ComposerWithCommentEnabledTest {
   @Test
   public void testEmpty() {
     String data = "";
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "" //
     };
 
@@ -180,7 +177,7 @@ public class ComposerWithCommentEnabledTest {
   @Test
   public void testParseWithOnlyComment() {
     String data = "# Comment";
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "Block Comment", //
         "MappingNode", //
     };
@@ -198,7 +195,7 @@ public class ComposerWithCommentEnabledTest {
         "key: # Comment\n" + //
         "  value\n";
 
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "MappingNode", //
         "    Tuple", //
         "        ScalarNode: key", //
@@ -221,7 +218,7 @@ public class ComposerWithCommentEnabledTest {
         "  value\n" + //
         "\n";
 
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "MappingNode", //
         "    Tuple", //
         "        ScalarNode: key", //
@@ -243,7 +240,7 @@ public class ComposerWithCommentEnabledTest {
     String data = "" + //
         "\n";
 
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "Block Comment", //
         "MappingNode", //
     };
@@ -263,7 +260,7 @@ public class ComposerWithCommentEnabledTest {
         "\n" + //
         "\n";
 
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "MappingNode", //
         "    Tuple", //
         "        Block Comment", //
@@ -289,7 +286,7 @@ public class ComposerWithCommentEnabledTest {
         "    hij\n" + //
         "\n";
 
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "MappingNode", //
         "    Tuple", //
         "        ScalarNode: abc", //
@@ -308,7 +305,7 @@ public class ComposerWithCommentEnabledTest {
   public void testDirectiveLineEndComment() {
     String data = "%YAML 1.1 #Comment\n---\n";
 
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "ScalarNode: " //
     };
 
@@ -328,7 +325,7 @@ public class ComposerWithCommentEnabledTest {
         "- item # InlineComment2\n" + //
         "# Comment\n";
 
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "MappingNode", //
         "    Tuple", //
         "        Block Comment", //
@@ -370,7 +367,7 @@ public class ComposerWithCommentEnabledTest {
         "# Block Comment7\n" + //
         "";
 
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "MappingNode", //
         "    Tuple", //
         "        Block Comment", //
@@ -437,7 +434,7 @@ public class ComposerWithCommentEnabledTest {
         "# Block Comment4\n" + //
         "";
 
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "SequenceNode", //
         "    Block Comment", //
         "    Block Comment", //
@@ -469,7 +466,7 @@ public class ComposerWithCommentEnabledTest {
         "# Block Comment2\n" + //
         "";
 
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "Block Comment", //
         "SequenceNode", //
         "    ScalarNode: item1", //
@@ -499,7 +496,7 @@ public class ComposerWithCommentEnabledTest {
         "abc: def # commment\n" + //
         "\n" + //
         "\n";
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "MappingNode", //
         "    Tuple", //
         "        Block Comment", "        ScalarNode: abc", //
@@ -510,7 +507,7 @@ public class ComposerWithCommentEnabledTest {
     };
 
     Composer sut = newComposerWithCommentsEnabled(data);
-    List<Node> result = Collections.singletonList(sut.getSingleNode().get());
+    List<Node> result = Collections.singletonList(sut.getSingleNode());
 
     printNodeList(result);
     assertNodesEqual(expected, result);
@@ -525,7 +522,7 @@ public class ComposerWithCommentEnabledTest {
         "abc: def # commment\n" + //
         "\n" + //
         "\n";
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "MappingNode", //
         "    Tuple", //
         "        Block Comment", //
@@ -539,7 +536,7 @@ public class ComposerWithCommentEnabledTest {
     };
 
     Composer sut = newComposerWithCommentsEnabled(data);
-    List<Node> result = Collections.singletonList(sut.getSingleNode().get());
+    List<Node> result = Collections.singletonList(sut.getSingleNode());
 
     printNodeList(result);
     assertNodesEqual(expected, result);
@@ -568,7 +565,7 @@ public class ComposerWithCommentEnabledTest {
     String data = "userProps:\n" + //
         "#password\n" + //
         "pass: mySecret\n";
-    String[] expected = new String[] { //
+    String[] expected = new String[]{ //
         "MappingNode", //
         "    Tuple", //
         "        ScalarNode: userProps", //
@@ -580,7 +577,7 @@ public class ComposerWithCommentEnabledTest {
     };
 
     Composer sut = newComposerWithCommentsEnabled(data);
-    List<Node> result = Collections.singletonList(sut.getSingleNode().get());
+    List<Node> result = Collections.singletonList(sut.getSingleNode());
 
     printNodeList(result);
     assertNodesEqual(expected, result);

--- a/src/test/java/org/snakeyaml/engine/v2/comments/EmitterWithCommentEnabledTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/comments/EmitterWithCommentEnabledTest.java
@@ -14,12 +14,6 @@
 package org.snakeyaml.engine.v2.comments;
 
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.api.Load;
@@ -29,21 +23,17 @@ import org.snakeyaml.engine.v2.common.FlowStyle;
 import org.snakeyaml.engine.v2.common.ScalarStyle;
 import org.snakeyaml.engine.v2.composer.Composer;
 import org.snakeyaml.engine.v2.emitter.Emitter;
-import org.snakeyaml.engine.v2.events.CommentEvent;
-import org.snakeyaml.engine.v2.events.DocumentEndEvent;
-import org.snakeyaml.engine.v2.events.DocumentStartEvent;
-import org.snakeyaml.engine.v2.events.ImplicitTuple;
-import org.snakeyaml.engine.v2.events.MappingEndEvent;
-import org.snakeyaml.engine.v2.events.MappingStartEvent;
-import org.snakeyaml.engine.v2.events.ScalarEvent;
-import org.snakeyaml.engine.v2.events.SequenceEndEvent;
-import org.snakeyaml.engine.v2.events.SequenceStartEvent;
-import org.snakeyaml.engine.v2.events.StreamEndEvent;
-import org.snakeyaml.engine.v2.events.StreamStartEvent;
+import org.snakeyaml.engine.v2.events.*;
 import org.snakeyaml.engine.v2.nodes.Node;
 import org.snakeyaml.engine.v2.parser.ParserImpl;
 import org.snakeyaml.engine.v2.scanner.StreamReader;
 import org.snakeyaml.engine.v2.serializer.Serializer;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class EmitterWithCommentEnabledTest {
@@ -241,7 +231,7 @@ public class EmitterWithCommentEnabledTest {
   @Test
   public void testKeepingNewLineInsideSequence() throws Exception {
     String data = "" + "\n" + "key:\n" +
-    // " \n" + // only supported in a sequence right now
+        // " \n" + // only supported in a sequence right now
         "- item1\n" +
         // "\n" + // Per Spec this is part of plain scalar above
         "- item2\n" +
@@ -340,36 +330,36 @@ public class EmitterWithCommentEnabledTest {
     StreamDataWriter output = new MyWriter();
     Emitter emitter = producePrettyFlowEmitter(output);
 
-    emitter.emit(new StreamStartEvent(Optional.empty(), Optional.empty()));
-    emitter.emit(new DocumentStartEvent(false, Optional.empty(), new HashMap<>(), Optional.empty(),
-        Optional.empty()));
-    emitter.emit(new MappingStartEvent(Optional.empty(), Optional.of("yaml.org,2002:map"), true,
+    emitter.emit(new StreamStartEvent(null, null));
+    emitter.emit(new DocumentStartEvent(false, null, new HashMap<>(), null,
+        null));
+    emitter.emit(new MappingStartEvent(null, "yaml.org,2002:map", true,
         FlowStyle.FLOW));
     emitter.emit(
-        new CommentEvent(CommentType.BLOCK, " I'm first", Optional.empty(), Optional.empty()));
+        new CommentEvent(CommentType.BLOCK, " I'm first", null, null));
     ImplicitTuple allImplicit = new ImplicitTuple(true, true);
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.of("yaml.org,2002:str"), allImplicit,
-        "a", ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.of("yaml.org,2002:str"), allImplicit,
-        "Hello", ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.of("yaml.org,2002:str"), allImplicit,
-        "b", ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
-    emitter.emit(new MappingStartEvent(Optional.empty(), Optional.of("yaml.org,2002:map"), true,
-        FlowStyle.FLOW, Optional.empty(), Optional.empty()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.of("yaml.org,2002:str"), allImplicit,
-        "one", ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.of("yaml.org,2002:str"), allImplicit,
-        "World", ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
+    emitter.emit(new ScalarEvent(null, "yaml.org,2002:str", allImplicit,
+        "a", ScalarStyle.PLAIN, null, null));
+    emitter.emit(new ScalarEvent(null, "yaml.org,2002:str", allImplicit,
+        "Hello", ScalarStyle.PLAIN, null, null));
+    emitter.emit(new ScalarEvent(null, "yaml.org,2002:str", allImplicit,
+        "b", ScalarStyle.PLAIN, null, null));
+    emitter.emit(new MappingStartEvent(null, "yaml.org,2002:map", true,
+        FlowStyle.FLOW, null, null));
+    emitter.emit(new ScalarEvent(null, "yaml.org,2002:str", allImplicit,
+        "one", ScalarStyle.PLAIN, null, null));
+    emitter.emit(new ScalarEvent(null, "yaml.org,2002:str", allImplicit,
+        "World", ScalarStyle.PLAIN, null, null));
     emitter
-        .emit(new CommentEvent(CommentType.BLOCK, " also me", Optional.empty(), Optional.empty()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.of("yaml.org,2002:str"), allImplicit,
-        "two", ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.of("yaml.org,2002:str"), allImplicit,
-        "eee", ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
-    emitter.emit(new MappingEndEvent(Optional.empty(), Optional.empty()));
-    emitter.emit(new MappingEndEvent(Optional.empty(), Optional.empty()));
-    emitter.emit(new DocumentEndEvent(false, Optional.empty(), Optional.empty()));
-    emitter.emit(new StreamEndEvent(Optional.empty(), Optional.empty()));
+        .emit(new CommentEvent(CommentType.BLOCK, " also me", null, null));
+    emitter.emit(new ScalarEvent(null, "yaml.org,2002:str", allImplicit,
+        "two", ScalarStyle.PLAIN, null, null));
+    emitter.emit(new ScalarEvent(null, "yaml.org,2002:str", allImplicit,
+        "eee", ScalarStyle.PLAIN, null, null));
+    emitter.emit(new MappingEndEvent(null, null));
+    emitter.emit(new MappingEndEvent(null, null));
+    emitter.emit(new DocumentEndEvent(false, null, null));
+    emitter.emit(new StreamEndEvent(null, null));
 
     String result = output.toString();
     final String data = "{\n" + "  # I'm first\n" + "  a: Hello,\n" + "  b: {\n"
@@ -383,16 +373,16 @@ public class EmitterWithCommentEnabledTest {
     StreamDataWriter output = new MyWriter();
     Emitter emitter = producePrettyFlowEmitter(output);
 
-    emitter.emit(new StreamStartEvent(Optional.empty(), Optional.empty()));
-    emitter.emit(new DocumentStartEvent(false, Optional.empty(), new HashMap<>(), Optional.empty(),
-        Optional.empty()));
-    emitter.emit(new MappingStartEvent(Optional.empty(), Optional.of("yaml.org,2002:map"), true,
-        FlowStyle.FLOW, Optional.empty(), Optional.empty()));
+    emitter.emit(new StreamStartEvent(null, null));
+    emitter.emit(new DocumentStartEvent(false, null, new HashMap<>(), null,
+        null));
+    emitter.emit(new MappingStartEvent(null, "yaml.org,2002:map", true,
+        FlowStyle.FLOW, null, null));
     emitter.emit(
-        new CommentEvent(CommentType.BLOCK, " nobody home", Optional.empty(), Optional.empty()));
-    emitter.emit(new MappingEndEvent(Optional.empty(), Optional.empty()));
-    emitter.emit(new DocumentEndEvent(false, Optional.empty(), Optional.empty()));
-    emitter.emit(new StreamEndEvent(Optional.empty(), Optional.empty()));
+        new CommentEvent(CommentType.BLOCK, " nobody home", null, null));
+    emitter.emit(new MappingEndEvent(null, null));
+    emitter.emit(new DocumentEndEvent(false, null, null));
+    emitter.emit(new StreamEndEvent(null, null));
 
     String result = output.toString();
     final String data = "{\n" + "  # nobody home\n" + "}\n";
@@ -406,20 +396,20 @@ public class EmitterWithCommentEnabledTest {
     Emitter emitter = producePrettyFlowEmitter(output);
     ImplicitTuple allImplicit = new ImplicitTuple(true, true);
 
-    emitter.emit(new StreamStartEvent(Optional.empty(), Optional.empty()));
-    emitter.emit(new DocumentStartEvent(false, Optional.empty(), new HashMap<>(), Optional.empty(),
-        Optional.empty()));
-    emitter.emit(new SequenceStartEvent(Optional.empty(), Optional.of("yaml.org,2002:seq"), true,
-        FlowStyle.FLOW, Optional.empty(), Optional.empty()));
-    emitter.emit(new CommentEvent(CommentType.BLOCK, " red", Optional.empty(), Optional.empty()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.of("yaml.org,2002:str"), allImplicit,
-        "one", ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
-    emitter.emit(new CommentEvent(CommentType.BLOCK, " blue", Optional.empty(), Optional.empty()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.of("yaml.org,2002:str"), allImplicit,
-        "two", ScalarStyle.PLAIN, Optional.empty(), Optional.empty()));
-    emitter.emit(new SequenceEndEvent(Optional.empty(), Optional.empty()));
-    emitter.emit(new DocumentEndEvent(false, Optional.empty(), Optional.empty()));
-    emitter.emit(new StreamEndEvent(Optional.empty(), Optional.empty()));
+    emitter.emit(new StreamStartEvent(null, null));
+    emitter.emit(new DocumentStartEvent(false, null, new HashMap<>(), null,
+        null));
+    emitter.emit(new SequenceStartEvent(null, "yaml.org,2002:seq", true,
+        FlowStyle.FLOW, null, null));
+    emitter.emit(new CommentEvent(CommentType.BLOCK, " red", null, null));
+    emitter.emit(new ScalarEvent(null, "yaml.org,2002:str", allImplicit,
+        "one", ScalarStyle.PLAIN, null, null));
+    emitter.emit(new CommentEvent(CommentType.BLOCK, " blue", null, null));
+    emitter.emit(new ScalarEvent(null, "yaml.org,2002:str", allImplicit,
+        "two", ScalarStyle.PLAIN, null, null));
+    emitter.emit(new SequenceEndEvent(null, null));
+    emitter.emit(new DocumentEndEvent(false, null, null));
+    emitter.emit(new StreamEndEvent(null, null));
 
     String result = output.toString();
     final String data = "[\n" + "  # red\n" + "  one,\n" + "  # blue\n" + "  two\n" + "]\n";
@@ -432,16 +422,16 @@ public class EmitterWithCommentEnabledTest {
     MyWriter output = new MyWriter();
     Emitter emitter = producePrettyFlowEmitter(output);
 
-    emitter.emit(new StreamStartEvent(Optional.empty(), Optional.empty()));
-    emitter.emit(new DocumentStartEvent(false, Optional.empty(), new HashMap<>(), Optional.empty(),
-        Optional.empty()));
-    emitter.emit(new SequenceStartEvent(Optional.empty(), Optional.of("yaml.org,2002:seq"), true,
-        FlowStyle.FLOW, Optional.empty(), Optional.empty()));
+    emitter.emit(new StreamStartEvent(null, null));
+    emitter.emit(new DocumentStartEvent(false, null, new HashMap<>(), null,
+        null));
+    emitter.emit(new SequenceStartEvent(null, "yaml.org,2002:seq", true,
+        FlowStyle.FLOW, null, null));
     emitter.emit(
-        new CommentEvent(CommentType.BLOCK, " nobody home", Optional.empty(), Optional.empty()));
-    emitter.emit(new SequenceEndEvent(Optional.empty(), Optional.empty()));
-    emitter.emit(new DocumentEndEvent(false, Optional.empty(), Optional.empty()));
-    emitter.emit(new StreamEndEvent(Optional.empty(), Optional.empty()));
+        new CommentEvent(CommentType.BLOCK, " nobody home", null, null));
+    emitter.emit(new SequenceEndEvent(null, null));
+    emitter.emit(new DocumentEndEvent(false, null, null));
+    emitter.emit(new StreamEndEvent(null, null));
 
     String result = output.toString();
     final String data = "[\n" + "  # nobody home\n" + "]\n";

--- a/src/test/java/org/snakeyaml/engine/v2/common/SpecVersionTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/common/SpecVersionTest.java
@@ -13,9 +13,6 @@
  */
 package org.snakeyaml.engine.v2.common;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -24,6 +21,9 @@ import org.snakeyaml.engine.v2.api.lowlevel.Compose;
 import org.snakeyaml.engine.v2.exceptions.YamlVersionException;
 import org.snakeyaml.engine.v2.nodes.ScalarNode;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 @Tag("fast")
 class SpecVersionTest {
 
@@ -31,7 +31,7 @@ class SpecVersionTest {
   @DisplayName("Version 1.2 is accepted")
   void version12() {
     LoadSettings settings = LoadSettings.builder().setLabel("spec 1.2").build();
-    ScalarNode node = (ScalarNode) new Compose(settings).composeString("%YAML 1.2\n---\nfoo").get();
+    ScalarNode node = (ScalarNode) new Compose(settings).composeString("%YAML 1.2\n---\nfoo");
     assertEquals("foo", node.getValue());
   }
 
@@ -39,7 +39,7 @@ class SpecVersionTest {
   @DisplayName("Version 1.3 is accepted by default")
   void version13() {
     LoadSettings settings = LoadSettings.builder().setLabel("spec 1.3").build();
-    ScalarNode node = (ScalarNode) new Compose(settings).composeString("%YAML 1.3\n---\nfoo").get();
+    ScalarNode node = (ScalarNode) new Compose(settings).composeString("%YAML 1.3\n---\nfoo");
     assertEquals("foo", node.getValue());
   }
 
@@ -55,7 +55,7 @@ class SpecVersionTest {
           }
         }).build();
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-        () -> new Compose(settings).composeString("%YAML 1.3\n---\nfoo").get());
+        () -> new Compose(settings).composeString("%YAML 1.3\n---\nfoo"));
     assertEquals("Too high.", exception.getMessage());
   }
 
@@ -64,7 +64,7 @@ class SpecVersionTest {
   void version20() {
     LoadSettings settings = LoadSettings.builder().setLabel("spec 2.0").build();
     YamlVersionException exception = assertThrows(YamlVersionException.class,
-        () -> new Compose(settings).composeString("%YAML 2.0\n---\nfoo").get());
+        () -> new Compose(settings).composeString("%YAML 2.0\n---\nfoo"));
     assertEquals("Version{major=2, minor=0}", exception.getMessage());
   }
 }

--- a/src/test/java/org/snakeyaml/engine/v2/composer/ComposerTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/composer/ComposerTest.java
@@ -13,11 +13,6 @@
  */
 package org.snakeyaml.engine.v2.composer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -25,6 +20,8 @@ import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.api.lowlevel.Compose;
 import org.snakeyaml.engine.v2.exceptions.ComposerException;
 import org.snakeyaml.engine.v2.nodes.Node;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("fast")
 class ComposerTest {
@@ -49,9 +46,8 @@ class ComposerTest {
   void composeAnchor() {
     String data = "--- &113\n{name: Bill, age: 18}";
     Compose compose = new Compose(LoadSettings.builder().build());
-    Optional<Node> optionalNode = compose.composeString(data);
-    assertTrue(optionalNode.isPresent());
-    Node node = optionalNode.get();
-    assertEquals("113", node.getAnchor().get().getValue());
+    Node optionalNode = compose.composeString(data);
+    assertNotNull(optionalNode);
+    assertEquals("113", optionalNode.getAnchor().getValue());
   }
 }

--- a/src/test/java/org/snakeyaml/engine/v2/constructor/DefaultConstructorTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/constructor/DefaultConstructorTest.java
@@ -13,12 +13,6 @@
  */
 package org.snakeyaml.engine.v2.constructor;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Optional;
-
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -27,6 +21,8 @@ import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
 import org.snakeyaml.engine.v2.nodes.Node;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("fast")
 class DefaultConstructorTest {
@@ -62,7 +58,7 @@ class MagicNullConstructor extends StandardConstructor {
 
   @NotNull
   @Override
-  public Optional<ConstructNode> findConstructorFor(@NotNull Node node) {
-    return Optional.of(new ConstructYamlNull());
+  public ConstructNode findConstructorFor(@NotNull Node node) {
+    return new ConstructYamlNull();
   }
 }

--- a/src/test/java/org/snakeyaml/engine/v2/constructor/StandardConstructorTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/constructor/StandardConstructorTest.java
@@ -13,9 +13,6 @@
  */
 package org.snakeyaml.engine.v2.constructor;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import java.util.Optional;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.LoadSettings;
@@ -23,15 +20,17 @@ import org.snakeyaml.engine.v2.api.lowlevel.Compose;
 import org.snakeyaml.engine.v2.nodes.Node;
 import org.snakeyaml.engine.v2.utils.TestUtils;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 @Tag("fast")
 class StandardConstructorTest {
 
   @Test
   void constructMergeExample() {
     Compose compose = new Compose(LoadSettings.builder().build());
-    Optional<Node> node = compose.composeString(TestUtils.getResource("/load/list1.yaml"));
+    Node node = compose.composeString(TestUtils.getResource("/load/list1.yaml"));
     StandardConstructor constructor = new StandardConstructor(LoadSettings.builder().build());
-    Object object = constructor.construct(node.get());
+    Object object = constructor.construct(node);
     assertNotNull(object);
   }
 }

--- a/src/test/java/org/snakeyaml/engine/v2/emitter/EmitterTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/emitter/EmitterTest.java
@@ -13,28 +13,10 @@
  */
 package org.snakeyaml.engine.v2.emitter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.StringWriter;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.TreeMap;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.snakeyaml.engine.v2.api.Dump;
-import org.snakeyaml.engine.v2.api.DumpSettings;
-import org.snakeyaml.engine.v2.api.DumpSettingsBuilder;
-import org.snakeyaml.engine.v2.api.Load;
-import org.snakeyaml.engine.v2.api.LoadSettings;
-import org.snakeyaml.engine.v2.api.StreamDataWriter;
+import org.snakeyaml.engine.v2.api.*;
 import org.snakeyaml.engine.v2.common.FlowStyle;
 import org.snakeyaml.engine.v2.common.ScalarStyle;
 import org.snakeyaml.engine.v2.events.DocumentStartEvent;
@@ -42,6 +24,11 @@ import org.snakeyaml.engine.v2.events.ImplicitTuple;
 import org.snakeyaml.engine.v2.events.ScalarEvent;
 import org.snakeyaml.engine.v2.events.StreamStartEvent;
 import org.snakeyaml.engine.v2.exceptions.ComposerException;
+
+import java.io.StringWriter;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("fast")
 public class EmitterTest {
@@ -143,11 +130,11 @@ public class EmitterTest {
     StreamDataWriter output = new MyDumperWriter();
     Emitter emitter = new Emitter(settings, output);
 
-    emitter.emit(new StreamStartEvent(Optional.empty(), Optional.empty()));
-    emitter.emit(new DocumentStartEvent(false, Optional.empty(), new HashMap<>(), Optional.empty(),
-        Optional.empty()));
-    emitter.emit(new ScalarEvent(Optional.empty(), Optional.empty(), new ImplicitTuple(true, false),
-        burger + halfBurger, ScalarStyle.DOUBLE_QUOTED, Optional.empty(), Optional.empty()));
+    emitter.emit(new StreamStartEvent(null, null));
+    emitter.emit(new DocumentStartEvent(false, null, new HashMap<>(), null,
+        null));
+    emitter.emit(new ScalarEvent(null, null, new ImplicitTuple(true, false),
+        burger + halfBurger, ScalarStyle.DOUBLE_QUOTED, null, null));
     String expected = "! \"\\U0001f354\\ud83c\"";
     assertEquals(expected, output.toString());
   }

--- a/src/test/java/org/snakeyaml/engine/v2/events/EventTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/events/EventTest.java
@@ -13,22 +13,19 @@
  */
 package org.snakeyaml.engine.v2.events;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.util.Optional;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.common.Anchor;
 import org.snakeyaml.engine.v2.exceptions.Mark;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("fast")
 class EventTest {
 
   @Test
   void testToString() {
-    Event alias = new AliasEvent(Optional.of(new Anchor("111")));
+    Event alias = new AliasEvent(new Anchor("111"));
     assertNotEquals(alias, alias.toString());
   }
 
@@ -36,7 +33,7 @@ class EventTest {
   void bothMarks() {
     Mark fake = new Mark("a", 0, 0, 0, new int[0], 0);
     NullPointerException exception = assertThrows(NullPointerException.class,
-        () -> new StreamStartEvent(Optional.empty(), Optional.of(fake)));
+        () -> new StreamStartEvent(null, fake));
     assertEquals("Both marks must be either present or absent.", exception.getMessage());
   }
 }

--- a/src/test/java/org/snakeyaml/engine/v2/parser/VersionTagsTupleTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/parser/VersionTagsTupleTest.java
@@ -13,19 +13,18 @@
  */
 package org.snakeyaml.engine.v2.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import com.google.common.collect.ImmutableMap;
-import java.util.Optional;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("fast")
 class VersionTagsTupleTest {
 
   @Test
   void testToString() {
-    VersionTagsTuple tuple = new VersionTagsTuple(Optional.empty(), ImmutableMap.of());
-    assertEquals("VersionTagsTuple<Optional.empty, {}>", tuple.toString());
+    VersionTagsTuple tuple = new VersionTagsTuple(null, ImmutableMap.of());
+    assertEquals("VersionTagsTuple<null, {}>", tuple.toString());
   }
 }

--- a/src/test/java/org/snakeyaml/engine/v2/representer/RepresentEntryTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/representer/RepresentEntryTest.java
@@ -13,15 +13,6 @@
  */
 package org.snakeyaml.engine.v2.representer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -35,6 +26,14 @@ import org.snakeyaml.engine.v2.common.ScalarStyle;
 import org.snakeyaml.engine.v2.emitter.Emitter;
 import org.snakeyaml.engine.v2.nodes.NodeTuple;
 import org.snakeyaml.engine.v2.serializer.Serializer;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("fast")
 public class RepresentEntryTest {
@@ -76,12 +75,12 @@ public class RepresentEntryTest {
     protected NodeTuple toNodeTuple(@NotNull Map.Entry<?, ?> entry) {
       NodeTuple tuple = super.toNodeTuple(entry);
       List<CommentLine> keyBlockComments = new ArrayList<>();
-      keyBlockComments.add(new CommentLine(Optional.empty(), Optional.empty(),
+      keyBlockComments.add(new CommentLine(null, null,
           "Key node block comment", CommentType.BLOCK));
       tuple.getKeyNode().setBlockComments(keyBlockComments);
 
       List<CommentLine> valueEndComments = new ArrayList<>();
-      valueEndComments.add(new CommentLine(Optional.empty(), Optional.empty(),
+      valueEndComments.add(new CommentLine(null, null,
           "Value node inline comment", CommentType.IN_LINE));
       tuple.getValueNode().setEndComments(valueEndComments);
 

--- a/src/test/java/org/snakeyaml/engine/v2/scanner/SimpleKeyTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/scanner/SimpleKeyTest.java
@@ -13,11 +13,10 @@
  */
 package org.snakeyaml.engine.v2.scanner;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @org.junit.jupiter.api.Tag("fast")
 class SimpleKeyTest {
@@ -25,9 +24,8 @@ class SimpleKeyTest {
   @Test
   @DisplayName("Resolve implicit integer")
   void testToString() {
-    SimpleKey simpleKey = new SimpleKey(0, true, 0, 0, 0, Optional.empty());
+    SimpleKey simpleKey = new SimpleKey(0, true, 0, 0, 0, null);
     assertEquals("SimpleKey - tokenNumber=0 required=true index=0 line=0 column=0",
         simpleKey.toString());
   }
 }
-

--- a/src/test/java/org/snakeyaml/engine/v2/tokens/TokenTest.java
+++ b/src/test/java/org/snakeyaml/engine/v2/tokens/TokenTest.java
@@ -13,21 +13,16 @@
  */
 package org.snakeyaml.engine.v2.tokens;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @org.junit.jupiter.api.Tag("fast")
 class TokenTest {
 
   @Test
   void testToString() {
-    Token token = new ScalarToken("a", true, Optional.empty(), Optional.empty());
+    Token token = new ScalarToken("a", true, null, null);
     assertEquals("<scalar> plain=true style=: value=a", token.toString());
   }
 }


### PR DESCRIPTION
fix #18 

Replaces all `Optional<>`s with a nullable equivalent (except for the Optional encoder/decoder).