### PR TITLE
setup git-branch-publish util

### DIFF
--- a/.github/workflows/git-branch-publish.yml
+++ b/.github/workflows/git-branch-publish.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run publish task
         run: >-
-          ./gradlew publishAllPublicationsToGitHubPublishRepository --stacktrace --info
+          ./gradlew publishAllPublicationsToGitBranchPublishRepository --stacktrace --info
         env:
           GIT_BRANCH_PUBLISH_DIR: ${{ runner.temp }}/m2
 

--- a/.github/workflows/git-branch-publish.yml
+++ b/.github/workflows/git-branch-publish.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   # get the current branch name https://stackoverflow.com/a/71158878/4161471
-  GIT_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  CURRENT_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
 
@@ -29,7 +29,7 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.GIT_BRANCH_NAME }}
+          ref: ${{ env.CURRENT_BRANCH_NAME }}
 
       - name: setup JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/git-branch-publish.yml
+++ b/.github/workflows/git-branch-publish.yml
@@ -1,0 +1,94 @@
+name: Git Branch Publish
+
+# Publish artifacts to a Git branch, which can be added as a Maven repository
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: "${{ github.workflow }}"
+  cancel-in-progress: false
+
+env:
+  # get the current branch name https://stackoverflow.com/a/71158878/4161471
+  GIT_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+
+  create-m2-publication:
+    runs-on: macos-latest # macOS can publish all Kotlin targets
+    environment:
+      name: artifacts
+      url: ${{ steps.deployment.outputs.page_url }}
+    timeout-minutes: 60
+
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.GIT_BRANCH_NAME }}
+
+      - name: setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Run publish task
+        run: >-
+          ./gradlew publishAllPublicationsToGitHubPublishRepository --stacktrace --info
+        env:
+          GIT_BRANCH_PUBLISH_DIR: ${{ runner.temp }}/m2
+
+      - name: upload build reports
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-report-${{ runner.os }}-${{ github.action }}
+          path: "**/build/reports/"
+          if-no-files-found: ignore
+
+      - name: upload local project publication
+        uses: actions/upload-artifact@v3
+        with:
+          name: m2-publication
+          path: ${{ env.GIT_BRANCH_PUBLISH_DIR }}
+        env:
+          GIT_BRANCH_PUBLISH_DIR: ${{ runner.temp }}/m2
+
+
+  commit-artifacts:
+    runs-on: ubuntu-latest
+    needs: create-m2-publication
+    environment:
+      name: artifacts
+      url: https://github.com/krzema12/snakeyaml-engine-kmp/tree/artifacts/m2
+    env:
+      CI_COMMIT_MESSAGE: artifacts
+      CI_COMMIT_AUTHOR: ${{ github.workflow }}
+    steps:
+      - name: Checkout artifacts branch
+        uses: actions/checkout@v3
+        with:
+          ref: artifacts
+
+      - name: download local project publication
+        uses: actions/download-artifact@v3
+        with:
+          name: m2-publication
+          path: m2
+
+      - name: git push
+        run: |
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "username@users.noreply.github.com"
+          git add .
+          git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -18,4 +18,31 @@ SnakeYAML Engine KMP is based on
 
 ## Status
 
-⚠️ SnakeYAML Engine KMP is **under development**. It is not published.
+⚠️ SnakeYAML Engine KMP is **under development**.
+
+### Snapshot releases
+
+Experimental snapshot versions of SnakeYAML Engine KMP are available. 
+They are published to a GitHub branch, which must be added as a
+[custom Gradle Plugin repository](https://docs.gradle.org/current/userguide/plugins.html#sec:custom_plugin_repositories)
+
+```kts
+// settings.gradle.kts
+
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+
+    // add the Dokkatoo snapshot repository
+    maven("https://github.com/krzema12/snakeyaml-engine-kmp/artifacts/m2/") {
+      name = "SnakeYAML Engine KMP Snapshots"
+      mavenContent {
+        // only include the relevant snapshots
+        includeGroup("org.snakeyaml")
+        snapshotsOnly()
+      }
+    }
+  }
+}
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 group = "org.snakeyaml"
 version = "2.7-SNAPSHOT"
-description = "SnakeYAML Engine"
+description = "SnakeYAML Engine KMP"
 
 kotlin {
     sourceSets {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     buildsrc.conventions.lang.`kotlin-multiplatform-jvm`
     buildsrc.conventions.lang.`kotlin-multiplatform-js`
     buildsrc.conventions.lang.`kotlin-multiplatform-native`
+    buildsrc.conventions.`git-branch-publish`
 }
 
 group = "org.snakeyaml"

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/git-branch-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/git-branch-publish.gradle.kts
@@ -1,0 +1,16 @@
+package buildsrc.conventions
+
+plugins {
+    `maven-publish`
+}
+
+val githubPublishDir: Provider<File> =
+    providers.environmentVariable("GIT_BRANCH_PUBLISH_DIR").map { file(it) }
+
+publishing {
+    repositories {
+        maven(githubPublishDir) {
+            name = "GitBranchPublish"
+        }
+    }
+}


### PR DESCRIPTION
Adds a GH Workflow and Gradle config that will publish SnakeYAML to the (orphaned) [artifacts](https://github.com/krzema12/snakeyaml-engine-kmp/tree/artifacts) branch.

@krzema12 can you do the following:

- [x] Creat a branch protection rule for `artifacts`. It doesn't need to do anything, except exist, because then it will make the branch non-deletable.
- [x] [Create an environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment), named 'artifacts'. (I did this for Dokkatoo, but I can't remember why...)