### PR TITLE
add concurrency & cancellation to 'build' workflow

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -5,6 +5,7 @@ import io.github.typesafegithub.workflows.actions.actions.CacheV3
 import io.github.typesafegithub.workflows.actions.actions.CheckoutV3
 import io.github.typesafegithub.workflows.actions.actions.SetupJavaV3
 import io.github.typesafegithub.workflows.actions.gradle.GradleBuildActionV2
+import io.github.typesafegithub.workflows.domain.Concurrency
 import io.github.typesafegithub.workflows.domain.RunnerType.*
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
@@ -19,6 +20,10 @@ workflow(
         PullRequest(),
     ),
     sourceFile = __FILE__.toPath(),
+    concurrency = Concurrency(
+        group = "\${{ github.workflow }} @ \${{ github.event.pull_request.head.label || github.head_ref || github.ref }}",
+        cancelInProgress = true,
+    ),
 ) {
     setOf(
         UbuntuLatest,

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,9 @@ on:
     branches:
     - 'main'
   pull_request: {}
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
 jobs:
   check_yaml_consistency:
     name: 'Check YAML consistency'


### PR DESCRIPTION
This will cancel in-progress workflows if a new commit is added.

Adding this is especially important now that most Kotlin targets are activated, so the tests take a long time to complete.