### PR TITLE
convert `val singleNode` to `fun getSingleNode()`

### DIFF
--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/api/lowlevel/ComposeString.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/api/lowlevel/ComposeString.kt
@@ -39,7 +39,7 @@ class ComposeString(
         Composer(
             settings,
             ParserImpl(settings, StreamReader(settings, yaml)),
-        ).singleNode
+        ).getSingleNode()
 
 
     /**

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/composer/Composer.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/composer/Composer.kt
@@ -67,30 +67,28 @@ class Composer(
      *
      * If the stream contains more than one document an exception is thrown.
      *
-     * @return The root node of the document or `null` if no document is
-     * available.
+     * @return The root node of the document or `null` if no document is available.
      */
-    val singleNode: Node?
-        get() {
-            // Drop the STREAM-START event.
-            parser.next()
-            // Compose a document if the stream is not empty.
-            val document = if (!parser.checkEvent(Event.ID.StreamEnd)) next() else null
-            // Ensure that the stream contains no more documents.
-            if (!parser.checkEvent(Event.ID.StreamEnd)) {
-                val event = parser.next()
-                val previousDocMark = document?.startMark
-                throw ComposerException(
-                    problem = "expected a single document in the stream",
-                    problemMark = previousDocMark,
-                    context = "but found another document",
-                    contextMark = event.startMark,
-                )
-            }
-            // Drop the STREAM-END event.
-            parser.next()
-            return document
+    fun getSingleNode(): Node? {
+        // Drop the STREAM-START event.
+        parser.next()
+        // Compose a document if the stream is not empty.
+        val document = if (!parser.checkEvent(Event.ID.StreamEnd)) next() else null
+        // Ensure that the stream contains no more documents.
+        if (!parser.checkEvent(Event.ID.StreamEnd)) {
+            val event = parser.next()
+            val previousDocMark = document?.startMark
+            throw ComposerException(
+                problem = "expected a single document in the stream",
+                problemMark = previousDocMark,
+                context = "but found another document",
+                contextMark = event.startMark,
+            )
         }
+        // Drop the STREAM-END event.
+        parser.next()
+        return document
+    }
 
     /**
      * Reads and composes the next document.
@@ -133,8 +131,8 @@ class Composer(
 
     private fun composeNode(parent: Node?): Node {
         blockCommentsCollector.collectEvents()
-        parent?.let { e: Node ->
-            recursiveNodes.add(e) // TODO add unit test for this line
+        if (parent != null) {
+            recursiveNodes.add(parent) // TODO add unit test for this line
         }
         val node: Node
         if (parser.checkEvent(Event.ID.Alias)) {
@@ -167,8 +165,8 @@ class Composer(
                 composeMappingNode(anchor)
             }
         }
-        parent?.let { o: Node ->
-            recursiveNodes.remove(o) // TODO add unit test for this line
+        if (parent != null) {
+            recursiveNodes.remove(parent) // TODO add unit test for this line
         }
         return node
     }

--- a/src/jvmMain/java/org/snakeyaml/engine/v2/api/Load.kt
+++ b/src/jvmMain/java/org/snakeyaml/engine/v2/api/Load.kt
@@ -79,7 +79,7 @@ class Load @JvmOverloads constructor(
      * @return deserialised YAML document
      */
     private fun loadOne(composer: Composer): Any? {
-        val nodeOptional = composer.singleNode
+        val nodeOptional = composer.getSingleNode()
         return constructor.constructSingleDocument(nodeOptional)
     }
 

--- a/src/jvmMain/java/org/snakeyaml/engine/v2/api/lowlevel/Compose.kt
+++ b/src/jvmMain/java/org/snakeyaml/engine/v2/api/lowlevel/Compose.kt
@@ -45,7 +45,7 @@ actual class Compose(
         Composer(
             settings,
             ParserImpl(settings, StreamReader(settings, yaml.readText())),
-        ).singleNode
+        ).getSingleNode()
 
     /**
      * Parse a YAML stream and produce [Node]
@@ -59,7 +59,7 @@ actual class Compose(
         Composer(
             settings,
             ParserImpl(settings, StreamReader(settings, YamlUnicodeReader(yaml.source()))),
-        ).singleNode
+        ).getSingleNode()
 
     /**
      * Parse a YAML stream and produce [Node]


### PR DESCRIPTION
convert `val singleNode` to `fun getSingleNode()` to better match SnakeYAML

https://github.com/snakeyaml/snakeyaml-engine/blob/5a35e1fe7f780d1405d5a03470f9f13d32b1638a/src/main/java/org/snakeyaml/engine/v2/composer/Composer.java#L113-L140