### PR TITLE
set up Maven Publish settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     buildsrc.conventions.lang.`kotlin-multiplatform-jvm`
     buildsrc.conventions.lang.`kotlin-multiplatform-js`
     buildsrc.conventions.lang.`kotlin-multiplatform-native`
+    buildsrc.conventions.publishing
     buildsrc.conventions.`git-branch-publish`
 }
 

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/publishing.gradle.kts
@@ -1,0 +1,144 @@
+package buildsrc.conventions
+
+import org.gradle.api.plugins.JavaBasePlugin.DOCUMENTATION_GROUP
+
+/**
+ * Conventions for publishing.
+ *
+ * Mostly focused on Maven Central publishing, which requires
+ *
+ * * a Javadoc JAR (even if the project is not a Java project)
+ * * artifacts are signed (and Gradle's [SigningPlugin] is outdated and does not have good support for lazy config/caching)
+ */
+
+plugins {
+    signing
+    `maven-publish`
+}
+
+
+//region Publication Properties
+// can be set in gradle.properties or environment variables, e.g. ORG_GRADLE_PROJECT_snake-kmp.ossrhUsername
+val ossrhUsername = providers.gradleProperty("snake-kmp.ossrhUsername")
+val ossrhPassword = providers.gradleProperty("snake-kmp.ossrhPassword")
+
+val signingKeyId: Provider<String> =
+    providers.gradleProperty("snake-kmp.signing.keyId")
+val signingKey: Provider<String> =
+    providers.gradleProperty("snake-kmp.signing.key")
+val signingPassword: Provider<String> =
+    providers.gradleProperty("snake-kmp.signing.password")
+val signingSecretKeyRingFile: Provider<String> =
+    providers.gradleProperty("snake-kmp.signing.secretKeyRingFile")
+
+val isReleaseVersion = provider { version.toString().endsWith("-SNAPSHOT") }
+
+val sonatypeReleaseUrl = isReleaseVersion.map { isRelease ->
+    if (isRelease) {
+        "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+    } else {
+        "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+    }
+}
+//endregion
+
+
+//region POM convention
+publishing {
+    publications.withType<MavenPublication>().configureEach {
+        pom {
+            name.convention("SnakeYAML Engine KMP")
+            description.convention("SnakeYAML Engine KMP is a YAML 1.2 processor for Kotlin Multiplatform")
+            url.convention("https://github.com/krzema12/snakeyaml-engine-kmp/")
+
+            scm {
+                connection.convention("scm:git:https://github.com/krzema12/snakeyaml-engine-kmp/")
+                developerConnection.convention("scm:git:https://github.com/krzema12/")
+                url.convention("https://github.com/krzema12/snakeyaml-engine-kmp")
+            }
+
+            licenses {
+                license {
+                    name.convention("Apache-2.0")
+                    url.convention("https://opensource.org/licenses/Apache-2.0")
+                }
+            }
+        }
+    }
+}
+//endregion
+
+
+//region Maven Central publishing/signing
+val javadocJarStub by tasks.registering(Jar::class) {
+    group = DOCUMENTATION_GROUP
+    description = "Empty Javadoc Jar (required by Maven Central)"
+    archiveClassifier.set("javadoc")
+}
+
+if (ossrhUsername.isPresent && ossrhPassword.isPresent) {
+    publishing {
+        repositories {
+            maven(sonatypeReleaseUrl) {
+                name = "SonatypeRelease"
+                credentials {
+                    username = ossrhUsername.get()
+                    password = ossrhPassword.get()
+                }
+            }
+            // Publish to a project-local Maven directory, for verification.
+            // To test, run:
+            // ./gradlew publishAllPublicationsToProjectLocalRepository
+            // and check $rootDir/build/maven-project-local
+            maven(rootProject.layout.buildDirectory.dir("maven-project-local")) {
+                name = "ProjectLocal"
+            }
+        }
+
+        // Maven Central requires Javadoc JAR, which our project doesn't
+        // have because it's not Java, so use an empty jar.
+        publications.withType<MavenPublication>().configureEach {
+            artifact(javadocJarStub)
+        }
+    }
+
+    signing {
+        logger.lifecycle("publishing.gradle.kts enabled signing for ${project.path}")
+        if (signingKeyId.isPresent && signingKey.isPresent && signingPassword.isPresent) {
+            useInMemoryPgpKeys(signingKeyId.get(), signingKey.get(), signingPassword.get())
+        } else {
+            useGpgCmd()
+        }
+    }
+
+    afterEvaluate {
+        // Register signatures in afterEvaluate, otherwise the signing plugin creates
+        // the signing tasks too early, before all the publications are added.
+        signing {
+            sign(publishing.publications)
+        }
+    }
+}
+//endregion
+
+
+//region Fix Gradle warning about signing tasks using publishing task outputs without explicit dependencies
+// https://youtrack.jetbrains.com/issue/KT-46466
+val signingTasks = tasks.withType<Sign>()
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    mustRunAfter(signingTasks)
+}
+//endregion
+
+
+//region publishing logging
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    val publicationGAV = provider { publication?.run { "$group:$artifactId:$version" } }
+    doLast("log publication GAV") {
+        if (publicationGAV.isPresent) {
+            logger.lifecycle("[task: ${path}] ${publicationGAV.get()}")
+        }
+    }
+}
+//endregion


### PR DESCRIPTION
Create a convention plugin for publishing to Maven Central.

- [ ] @krzema12 register a new artifact on Maven Central
- [ ] Add publishing properties to `$GRADLE_USER_HOME/gradle.properties`
    
    ```properties
    #$GRADLE_USER_HOME/gradle.properties
    
    snake-kmp.ossrhUsername=
    snake-kmp.ossrhPassword=
    snake-kmp.signing.keyId=
    snake-kmp.signing.key=
    snake-kmp.signing.password=
    snake-kmp.signing.secretKeyRingFile=
    ```
- [ ] run `./gradlew publishAllPublicationsToProjectLocalRepository` to test and check `$rootDir/build/maven-project-local`. All files should be signed.

   Note that macOS is the only OS that supports publishing all Kotlin Multiplatform targets.



When publishing for real, make sure to add `--no-parallel` and `--no-configuration-cache` (because Maven Central can barely handle even slow uploads, let alone parallel uploads. And the Gradle signing plugins are outdated and can't handle configuration cache)