### PR TITLE
Kotlin code improvements 

### DIFF
--- a/src/commonMain/kotlin/org/snakeyaml/engine/internal/math.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/internal/math.kt
@@ -5,5 +5,3 @@ internal expect fun createBigInteger(value: String, radix: Int = 10): Number
 internal fun String.toBigInteger(radix: Int = 10): Number = createBigInteger(this, radix)
 
 internal expect fun createBigDecimal(value: String): Number
-
-internal fun String.toBigDecimal(radix: Int): Number = createBigDecimal(this)

--- a/src/commonMain/kotlin/org/snakeyaml/engine/internal/system.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/internal/system.kt
@@ -4,6 +4,9 @@ import kotlin.jvm.JvmInline
 
 /**
  * Fetch an environment variable from the current system.
+ *
+ * @param key - the name of the variable
+ * @returns the value, or `null` if the environment variable is not present or has no value
  */
 internal expect fun getEnvironmentVariable(key: String): String?
 

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/api/ConstructNode.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/api/ConstructNode.kt
@@ -17,7 +17,7 @@ import org.snakeyaml.engine.v2.exceptions.YamlEngineException
 import org.snakeyaml.engine.v2.nodes.Node
 
 /**
- * Provide a way to construct a Java instance from the composed Node. Support recursive objects if
+ * Provide a way to construct an instance from the composed [Node]. Support recursive objects if
  * it is required. (create Native Data Structure out of Node Graph) (this is the opposite for
  * Represent)
  *
@@ -25,22 +25,21 @@ import org.snakeyaml.engine.v2.nodes.Node
  */
 interface ConstructNode {
     /**
-     * Construct a Java instance with all the properties injected when it is possible.
+     * Construct an instance, with all the properties injected when it is possible.
      *
      * @param node composed [Node]
-     * @return a complete Java instance or empty collection instance if it is recursive
+     * @return a complete Java instance, or an empty collection instance if it is recursive
      */
     fun construct(node: Node?): Any?
 
     /**
      * Apply the second step when constructing recursive structures. Because the instance is already
      * created it can assign a reference to itself. (no need to implement this method for
-     * non-recursive data structures). Fail with a reminder to provide the second step for a recursive
+     * non-recursive data structures). Fails with a reminder to provide the second step for a recursive
      * structure
      *
      * @param node composed [Node]
-     * @param object the instance constructed earlier by `construct(Node node)` for the
-     * provided Node
+     * @param object the instance constructed earlier by [construct] for the provided [Node]
      */
     fun constructRecursive(node: Node, `object`: Any) {
         check(!node.isRecursive) { "Not implemented in ${this::class}" }

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/api/LoadSettingsBuilder.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/api/LoadSettingsBuilder.kt
@@ -22,7 +22,7 @@ import org.snakeyaml.engine.v2.schema.JsonSchema
 import org.snakeyaml.engine.v2.schema.Schema
 
 /**
- * Builder pattern implementation for LoadSettings
+ * Builder pattern implementation for [LoadSettings]
  */
 class LoadSettingsBuilder internal constructor() {
     private val customProperties: MutableMap<SettingKey, Any> = HashMap()

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/api/lowlevel/Parse.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/api/lowlevel/Parse.kt
@@ -1,7 +1,10 @@
 package org.snakeyaml.engine.v2.api.lowlevel
 
+import org.snakeyaml.engine.v2.api.LoadSettings
 import org.snakeyaml.engine.v2.events.Event
 
-expect class Parse {
+expect class Parse(
+    settings: LoadSettings
+) {
     fun parseString(yaml: String): Iterable<Event>
 }

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/common/CharConstants.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/common/CharConstants.kt
@@ -17,7 +17,12 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 class CharConstants private constructor(content: String) {
-    val contains = BooleanArray(ASCII_SIZE) { false }
+    val contains: BooleanArray
+
+    init {
+        val contentCodes = content.map { it.code }
+        contains = BooleanArray(ASCII_SIZE) { it in contentCodes }
+    }
 
     fun has(c: Int): Boolean = c < ASCII_SIZE && contains[c]
 
@@ -27,14 +32,9 @@ class CharConstants private constructor(content: String) {
 
     fun hasNo(c: Int, additional: String): Boolean = !has(c, additional)
 
-    init {
-        content.forEach {
-            contains[it.code] = true
-        }
-    }
-
     companion object {
-        private const val ALPHA_S = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-_"
+        private const val ALPHA_S =
+            "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-_"
         private const val LINEBR_S = "\n"
         private const val FULL_LINEBR_S = "\r" + LINEBR_S
         private const val NULL_OR_LINEBR_S = "\u0000" + FULL_LINEBR_S
@@ -42,9 +42,16 @@ class CharConstants private constructor(content: String) {
         private const val NULL_BL_T_LINEBR_S = "\t" + NULL_BL_LINEBR_S
         private const val NULL_BL_T_S = "\u0000 \t"
 
-        // the suffix must not contain the “[”, “]”, “{”, “}” and “,” characters.
-        // These characters would cause ambiguity with flow collection structures.
-        // https://yaml.org/spec/1.2.2/#691-node-tags
+        /**
+         * The suffix must not contain the characters
+         *
+         * ```text
+         * []{},.
+         * ```
+         *
+         * These characters would cause ambiguity with flow collection structures.
+         * https://yaml.org/spec/1.2.2/#691-node-tags
+         */
         private const val URI_CHARS_SUFFIX_S = "$ALPHA_S-;/?:@&=+\$_.!~*'()%"
 
         @JvmField

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/composer/Composer.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/composer/Composer.kt
@@ -203,8 +203,8 @@ class Composer(
             startMark = ev.startMark,
             endMark = ev.endMark,
         )
-        anchor?.let { a: Anchor ->
-            registerAnchor(a, node)
+        if (anchor != null) {
+            registerAnchor(anchor, node)
         }
         node.blockComments = (blockComments)
         node.inLineComments = (inlineCommentsCollector.collectEvents().consume())
@@ -241,8 +241,8 @@ class Composer(
         if (startEvent.isFlow()) {
             node.blockComments = (blockCommentsCollector.consume())
         }
-        anchor?.let { a: Anchor ->
-            registerAnchor(a, node)
+        if (anchor != null) {
+            registerAnchor(anchor, node)
         }
         while (!parser.checkEvent(Event.ID.SequenceEnd)) {
             blockCommentsCollector.collectEvents()
@@ -258,7 +258,7 @@ class Composer(
         node.setEndMark(endEvent.endMark)
         inlineCommentsCollector.collectEvents()
         if (!inlineCommentsCollector.isEmpty()) {
-            node.inLineComments = (inlineCommentsCollector.consume())
+            node.inLineComments = inlineCommentsCollector.consume()
         }
         return node
     }
@@ -280,20 +280,20 @@ class Composer(
             nodeTag = Tag(tag)
             resolved = false
         }
-        val children: MutableList<NodeTuple> = ArrayList()
+        val children = mutableListOf<NodeTuple>()
         val node = MappingNode(
             tag = nodeTag,
-            resolved = resolved,
             value = children,
             flowStyle = startEvent.flowStyle,
+            resolved = resolved,
             startMark = startEvent.startMark,
             endMark = null,
         )
         if (startEvent.isFlow()) {
             node.blockComments = (blockCommentsCollector.consume())
         }
-        anchor?.let { a: Anchor ->
-            registerAnchor(a, node)
+        if (anchor != null) {
+            registerAnchor(anchor, node)
         }
         while (!parser.checkEvent(Event.ID.MappingEnd)) {
             blockCommentsCollector.collectEvents()
@@ -309,7 +309,7 @@ class Composer(
         node.setEndMark(endEvent.endMark)
         inlineCommentsCollector.collectEvents()
         if (!inlineCommentsCollector.isEmpty()) {
-            node.inLineComments = (inlineCommentsCollector.consume())
+            node.inLineComments = inlineCommentsCollector.consume()
         }
         return node
     }

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/constructor/BaseConstructor.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/constructor/BaseConstructor.kt
@@ -84,9 +84,8 @@ abstract class BaseConstructor(
     private fun fillRecursive() {
         if (maps2fill.isNotEmpty()) {
             for (entry in maps2fill) {
-                val keyValueTuple =
-                    entry.value2
-                entry.value1[keyValueTuple.value1] = keyValueTuple.value2
+                val (value1, value2) = entry.value2
+                entry.value1[value1] = value2
             }
             maps2fill.clear()
         }
@@ -99,7 +98,7 @@ abstract class BaseConstructor(
     }
 
     /**
-     * Construct object from the specified Node. Return existing instance if the node is already
+     * Construct object from the specified [Node]. Return existing instance if [node] is already
      * constructed.
      *
      * @param node Node to be constructed
@@ -110,8 +109,8 @@ abstract class BaseConstructor(
     }
 
     /**
-     * Construct object from the specified Node. It does not check if existing instance the node is
-     * already constructed.
+     * Construct object from the specified [Node]. It does not check if existing instance of [node] is already
+     * constructed.
      *
      * @param node - the source
      * @return instantiated object
@@ -342,5 +341,8 @@ abstract class BaseConstructor(
         sets2fill.add(0, RecursiveTuple(set, key))
     }
 
-    internal class RecursiveTuple<T, K>(val value1: T, val value2: K)
+    private data class RecursiveTuple<T, K>(
+        val value1: T,
+        val value2: K,
+    )
 }

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/events/CollectionStartEvent.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/events/CollectionStartEvent.kt
@@ -54,9 +54,9 @@ abstract class CollectionStartEvent(
 
     override fun toString(): String {
         return buildString {
-            anchor?.let { a -> append(" &$a") }
+            if (anchor != null) append(" &$anchor")
             if (!implicit) {
-                tag?.let { theTag: String -> append(" <$theTag>") }
+                if (tag != null) append(" <$tag>")
             }
         }
     }

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/events/ScalarEvent.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/events/ScalarEvent.kt
@@ -67,9 +67,9 @@ class ScalarEvent @JvmOverloads constructor(
     override fun toString(): String {
         return buildString {
             append("=VAL")
-            anchor?.let { a -> append(" &$a") }
+            if (anchor != null) append(" &$anchor")
             if (implicit.bothFalse()) {
-                tag?.let { theTag: String -> append(" <$theTag>") }
+                if (tag != null) append(" <$tag>")
             }
             append(" ")
             append(scalarStyle.toString())
@@ -80,7 +80,7 @@ class ScalarEvent @JvmOverloads constructor(
     fun escapedValue(): String {
         return value
             .toCodePoints()
-            .filter { i: Int -> i < Char.MAX_VALUE.code }
+            .filter { it < Char.MAX_VALUE.code }
             .joinToString("") { ch: Int ->
                 CharConstants.escapeChar(ch.toChar())
             }

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/MissingEnvironmentVariableException.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/MissingEnvironmentVariableException.kt
@@ -17,4 +17,19 @@ package org.snakeyaml.engine.v2.exceptions
  * Indicate missing mandatory environment variable in the template
  * @param message - error message
  */
-class MissingEnvironmentVariableException(message: String) : YamlEngineException(message)
+class MissingEnvironmentVariableException(message: String) : YamlEngineException(message) {
+
+    companion object {
+        internal fun forMissingVariable(
+            name: String,
+            value: String,
+        ): MissingEnvironmentVariableException =
+            MissingEnvironmentVariableException("Missing mandatory variable $name: $value")
+
+        internal fun forEmptyVariable(
+            name: String,
+            value: String,
+        ): MissingEnvironmentVariableException =
+            MissingEnvironmentVariableException("Empty mandatory variable $name: $value")
+    }
+}

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/nodes/CollectionNode.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/nodes/CollectionNode.kt
@@ -22,7 +22,7 @@ import kotlin.jvm.JvmOverloads
  *
  * @param[flowStyle] Serialization style of this collection
  */
-abstract class CollectionNode<T> @JvmOverloads constructor(
+sealed class CollectionNode<T> @JvmOverloads constructor(
     tag: Tag,
     var flowStyle: FlowStyle,
     startMark: Mark?,

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/nodes/Node.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/nodes/Node.kt
@@ -30,7 +30,7 @@ import kotlin.jvm.JvmOverloads
  * @param startMark - start mark when available
  * @param endMark - end mark when available
  */
-abstract class Node @JvmOverloads constructor(
+sealed class Node @JvmOverloads constructor(
     /**
      * Tag of this node.
      *

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/nodes/NodeTuple.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/nodes/NodeTuple.kt
@@ -18,9 +18,12 @@ package org.snakeyaml.engine.v2.nodes
  * @param[keyNode] the node used as the key
  * @param[valueNode] the node used as the value
  */
-data class NodeTuple(
+class NodeTuple(
     val keyNode: Node,
     val valueNode: Node,
 ) {
+    operator fun component1(): Node = keyNode
+    operator fun component2(): Node = valueNode
+
     override fun toString(): String = "<NodeTuple keyNode=$keyNode; valueNode=$valueNode>"
 }

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/parser/ParserImpl.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/parser/ParserImpl.kt
@@ -335,12 +335,12 @@ class ParserImpl(
 
 
     /**
-     * <pre>
+     * ```text
      * block_mapping     ::= BLOCK-MAPPING_START
      * ((KEY block_node_or_indentless_sequence?)?
      * (VALUE block_node_or_indentless_sequence?)?)*
      * BLOCK-END
-    </pre> *
+     * ```
      */
     private fun processEmptyScalar(mark: Mark?): Event {
         return ScalarEvent(
@@ -490,7 +490,7 @@ class ParserImpl(
     }
 
     /**
-     * ```
+     * ```text
      *  block_node_or_indentless_sequence ::= ALIAS
      *                | properties (block_content | indentless_block_sequence)?
      *                | block_content

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/serializer/Serializer.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/serializer/Serializer.kt
@@ -48,7 +48,9 @@ class Serializer(
             ),
         )
         anchorNode(node)
-        settings.explicitRootTag?.let { tag -> node.tag = tag }
+        if (settings.explicitRootTag != null) {
+            node.tag = settings.explicitRootTag
+        }
         serializeNode(node)
         emitable.emit(DocumentEndEvent(settings.isExplicitEnd))
         serializedNodes.clear()

--- a/src/commonTest/kotlin/org/snakeyaml/engine/SimpleEndToEndTest.kt
+++ b/src/commonTest/kotlin/org/snakeyaml/engine/SimpleEndToEndTest.kt
@@ -3,7 +3,7 @@ package org.snakeyaml.engine
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.snakeyaml.engine.v2.api.DumpSettings
-import org.snakeyaml.engine.v2.api.StreamDataWriter
+import org.snakeyaml.engine.v2.api.StringStreamDataWriter
 import org.snakeyaml.engine.v2.common.FlowStyle
 import org.snakeyaml.engine.v2.common.ScalarStyle
 import org.snakeyaml.engine.v2.emitter.Emitter
@@ -12,22 +12,8 @@ import org.snakeyaml.engine.v2.events.*
 class SimpleEndToEndTest : FunSpec({
     test("simple case") {
         // Given
-        val settings = DumpSettings.builder()
-            .build()
-        val stringBuilder = StringBuilder()
-        val writer = object : StreamDataWriter {
-            override fun flush() {
-                // no-op
-            }
-
-            override fun write(str: String) {
-                stringBuilder.append(str)
-            }
-
-            override fun write(str: String, off: Int, len: Int) {
-                stringBuilder.append(str)
-            }
-        }
+        val settings = DumpSettings.builder().build()
+        val writer = StringStreamDataWriter()
         val emitter = Emitter(opts = settings, stream = writer)
 
         // When
@@ -45,7 +31,7 @@ class SimpleEndToEndTest : FunSpec({
         emitter.emit(StreamEndEvent())
 
         // Then
-        stringBuilder.toString() shouldBe """
+        writer.toString() shouldBe """
             foo: bar
             baz: goo
 

--- a/src/jsMain/kotlin/org/snakeyaml/engine/v2/api/lowlevel/Parse.kt
+++ b/src/jsMain/kotlin/org/snakeyaml/engine/v2/api/lowlevel/Parse.kt
@@ -3,7 +3,7 @@ package org.snakeyaml.engine.v2.api.lowlevel
 import org.snakeyaml.engine.v2.api.LoadSettings
 import org.snakeyaml.engine.v2.events.Event
 
-actual class Parse(
+actual class Parse actual constructor(
     settings: LoadSettings,
 ) {
     private val parseString = ParseString(settings)

--- a/src/jvmMain/java/org/snakeyaml/engine/v2/api/lowlevel/Parse.kt
+++ b/src/jvmMain/java/org/snakeyaml/engine/v2/api/lowlevel/Parse.kt
@@ -26,7 +26,7 @@ import java.io.Reader
  * Read the input stream and parse the content into events (opposite for Present or Emit)
  * @param settings - configuration
  */
-actual class Parse(
+actual class Parse actual constructor(
     private val settings: LoadSettings,
 ) {
     private val parseString = ParseString(settings)

--- a/src/nativeMain/kotlin/org/snakeyaml/engine/v2/api/lowlevel/Parse.kt
+++ b/src/nativeMain/kotlin/org/snakeyaml/engine/v2/api/lowlevel/Parse.kt
@@ -3,7 +3,7 @@ package org.snakeyaml.engine.v2.api.lowlevel
 import org.snakeyaml.engine.v2.api.LoadSettings
 import org.snakeyaml.engine.v2.events.Event
 
-actual class Parse(
+actual class Parse actual constructor(
     settings: LoadSettings,
 ) {
     private val parseString = ParseString(settings)


### PR DESCRIPTION
code and docs tidying, in preparation for YAML Test Suites #59 

- remove unused `toBigDecimal` function
- avoid using `!!` to force non-null
- update Parse to have multiplatform constructor
- add/adjust docs and docs formatting
- avoid using scope functions for simple checks (scope functions tend to be more difficult to read)
- refactor environment variable fetching (improve legibility, and prepare for multiplatform testing)
- use sealed classes where possible (because the classes are not intended to be extended by external libraries)
- convert `NodeTuple` to regular class (data classes ABI is more difficult to maintain)
- re-write while-loops to avoid awkward scope functions and variable assignments
- Replace custom `StreamDataWriter` in test with existing `StringStreamDataWriter`