### PR TITLE
tidy build config after Gradle & Kotlin updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
             kotlin.srcDirs(tasks.yamlTestSuiteDataSources)
 
             dependencies {
-                implementation(platform("io.kotest:kotest-bom:5.8.0"))
+                implementation(project.dependencies.platform("io.kotest:kotest-bom:5.8.0"))
                 implementation("io.kotest:kotest-framework-engine")
                 implementation("io.kotest:kotest-framework-api")
                 implementation("io.kotest:kotest-assertions-core")

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-js.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-js.gradle.kts
@@ -7,11 +7,9 @@ plugins {
 }
 
 kotlin {
-    targets {
-        js(IR) {
-            browser()
-            nodejs()
-        }
+    js(IR) {
+        browser()
+        nodejs()
     }
 }
 

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-native.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform-native.gradle.kts
@@ -7,33 +7,6 @@ plugins {
 }
 
 kotlin {
-
-    // Native targets all extend commonMain and commonTest.
-    //
-    // Some targets (ios, tvos, watchos) are shortcuts provided by the Kotlin DSL, that
-    // provide additional targets, except for 'simulators' which must be defined manually.
-    // https://kotlinlang.org/docs/multiplatform-share-on-platforms.html#use-target-shortcuts
-    //
-    // common/
-    // └── native/
-    //     ├── linuxX64
-    //     ├── mingwX64
-    //     ├── macosX64
-    //     ├── macosArm64
-    //     ├── ios/ (shortcut)
-    //     │   ├── iosArm64
-    //     │   ├── iosX64
-    //     │   └── iosSimulatorArm64
-    //     ├── tvos/ (shortcut)
-    //     │   ├── tvosArm64
-    //     │   ├── tvosX64
-    //     │   └── tvosSimulatorArm64Main
-    //     └── watchos/ (shortcut)
-    //         ├── watchosArm32
-    //         ├── watchosArm64
-    //         ├── watchosX64
-    //         └── watchosSimulatorArm64Main
-
     linuxX64()
 
     mingwX64()
@@ -51,52 +24,4 @@ kotlin {
     //iosSimulatorArm64()
     //tvosSimulatorArm64()
     //watchosSimulatorArm64()
-
-    @Suppress("UNUSED_VARIABLE")
-    sourceSets {
-        val commonMain by getting {}
-        val commonTest by getting {}
-
-        val nativeMain by creating { dependsOn(commonMain) }
-        val nativeTest by creating { dependsOn(commonTest) }
-
-        // Linux
-        val linuxX64Main by getting { dependsOn(nativeMain) }
-        val linuxX64Test by getting { dependsOn(nativeTest) }
-
-        // Windows - MinGW
-        val mingwX64Main by getting { dependsOn(nativeMain) }
-        val mingwX64Test by getting { dependsOn(nativeTest) }
-
-        // Apple - macOS
-        val macosArm64Main by getting { dependsOn(nativeMain) }
-        val macosArm64Test by getting { dependsOn(nativeTest) }
-
-        val macosX64Main by getting { dependsOn(nativeMain) }
-        val macosX64Test by getting { dependsOn(nativeTest) }
-
-        //// Apple - iOS
-        //val iosMain by getting { dependsOn(nativeMain) }
-        //val iosTest by getting { dependsOn(nativeTest) }
-
-        //val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
-        //val iosSimulatorArm64Test by getting { dependsOn(iosTest) }
-
-        //// Apple - tvOS
-        //val tvosMain by getting { dependsOn(nativeMain) }
-        //val tvosTest by getting { dependsOn(nativeTest) }
-
-        //val tvosSimulatorArm64Main by getting { dependsOn(tvosMain) }
-        //val tvosSimulatorArm64Test by getting { dependsOn(tvosTest) }
-
-        //// Apple - watchOS
-        //val watchosMain by getting { dependsOn(nativeMain) }
-        //val watchosTest by getting { dependsOn(nativeTest) }
-
-        //val watchosSimulatorArm64Main by getting { dependsOn(watchosMain) }
-        //val watchosSimulatorArm64Test by getting { dependsOn(watchosTest) }
-
-        // val iosArm32Main by getting { dependsOn(desktopMain) }
-        // val iosArm32Test by getting { dependsOn(nativeTest) }
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,7 @@
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 org.gradle.caching=true
-# TODO https://github.com/krzema12/snakeyaml-engine-kmp/issues/46 re-enable configuration cache
-org.gradle.unsafe.configuration-cache=false
-org.gradle.unsafe.configuration-cache-problems=warn
-
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache-problems=warn
 org.gradle.parallel=true
 org.gradle.welcome=never


### PR DESCRIPTION
- enable Gradle config cache (Kotlin 1.9 is now compatible)
- update Gradle config cache property names
- use Kotlin default hierarchy https://kotlinlang.org/docs/multiplatform-hierarchy.html#default-hierarchy-template
- fix Kotlin config deprecations