### PR TITLE
Refined Renovate settings

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,10 +1,51 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "config:base",
+    "config:base"
   ],
+  enabled: true,
+  enabledManagers: [
+    "gradle",
+    "gradle-wrapper",
+    "github-actions",
+  ],
+  // Will auto-merge directly, without a PR, if tests pass - else, makes a PR.
+  // Must add Renovate to 'Allow specified actors to bypass required pull requests'
+  // in branch protection rule
+  automergeType: "branch",
+  platformAutomerge: true,
+  ignoreTests: false,
+  packageRules: [
+    {
+      description: "auto-merge all but major releases",
+      matchUpdateTypes: [
+        "minor",
+        "patch",
+        "pin",
+        "digest",
+      ],
+      automerge: true,
+    }
+  ],
+  timezone: "Etc/UTC",
+  schedule: [
+    // loosely limit to Europe daytime, so we don't get pinged in the middle of the night
+    "after 10am", "before 5pm",
+  ],
+  stabilityDays: 14,
+  //  suppressNotifications: [
+  //    "artifactErrors",
+  //    "branchAutomergeFailure",
+  //    "configErrorIssue",
+  //    "deprecationWarningIssues",
+  //    "lockFileErrors",
+  //    "onboardingClose",
+  //    "prEditedNotification",
+  //    "prIgnoreNotification",
+  //  ],
+  prCreation: "status-success",
+  semanticCommits: "disabled",
   ignorePaths: [
-      "src/jvmTest/resources/",
-  ],
-  automerge: true,
+    "src/jvmTest/resources/"
+  ]
 }


### PR DESCRIPTION
fix #86 

- Limit times that Renovate will open PRs to avoid late-night spam
- 14 day stability period to reduce eagerness, and will help reduce noise if a release is bugged and has multiple releases in succession
- pre-create & test branches so PRs should only be made if the test-branches succeed.


I've used these settings in https://github.com/adamko-dev/kotlinx-serialization-typescript-generator and I'm satisfied - but feel free to refine them if you'd like.