### PR TITLE
fix test parseManyAliasesForCollections

### DIFF
--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/references/ReferencesTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/references/ReferencesTest.java
@@ -97,7 +97,7 @@ public class ReferencesTest {
   @DisplayName("Parsing with aliases may take a lot of time, CPU and memory")
   public void parseManyAliasesForCollections() {
     final var minDuration = Duration.ofMillis(400);
-    final var maxDuration = Duration.ofSeconds(9);
+    final var maxDuration = Duration.ofSeconds(15);
     assertTimeout(maxDuration, () -> {
       String output = createDump(25);
       // Load

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/references/ReferencesTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/references/ReferencesTest.java
@@ -99,7 +99,7 @@ public class ReferencesTest {
   public void parseManyAliasesForCollections() {
     final var minDuration = Duration.ofMillis(400);
     final var maxDuration = Duration.ofSeconds(15);
-    assertTimeout(maxDuration, () -> {
+    final var timeElapsed = assertTimeout(maxDuration, () -> {
       String output = createDump(25);
       // Load
       final var start = Instant.now();
@@ -108,12 +108,12 @@ public class ReferencesTest {
       Load load = new Load(settings);
       load.loadFromString(output);
       final var finish = Instant.now();
-      final var timeElapsed = Duration.between(start, finish);
-      assertTrue(
-        timeElapsed.compareTo(minDuration) > 0, /* timeElapsed > minDuration */
-        "Expected elapsed time (" + (timeElapsed.toMillis() / 1000f) + ") seconds > minDuration (" + (minDuration.toMillis() / 1000f) + " seconds)"
-      );
+      return Duration.between(start, finish);
     });
+    assertTrue(
+      timeElapsed.compareTo(minDuration) > 0, /* timeElapsed > minDuration */
+      "Expected elapsed time (" + (timeElapsed.toMillis() / 1000f) + ") seconds > minDuration (" + (minDuration.toMillis() / 1000f) + " seconds)"
+    );
   }
 
   @Test

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/references/ReferencesTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/references/ReferencesTest.java
@@ -37,18 +37,18 @@ public class ReferencesTest {
    * @return YAML to parse
    */
   private String createDump(int size) {
-    LinkedHashMap root = new LinkedHashMap();
-    LinkedHashMap s1, s2, t1, t2;
+    LinkedHashMap<Object, Object> root = new LinkedHashMap<>();
+    LinkedHashMap<Object, Object> s1, s2, t1, t2;
     s1 = root;
-    s2 = new LinkedHashMap();
+    s2 = new LinkedHashMap<>();
     /*
      * the time to parse grows very quickly SIZE -> time to parse in seconds 25 -> 1 26 -> 2 27 -> 3
      * 28 -> 8 29 -> 13 30 -> 28 31 -> 52 32 -> 113 33 -> 245 34 -> 500
      */
     for (int i = 0; i < size; i++) {
 
-      t1 = new LinkedHashMap();
-      t2 = new LinkedHashMap();
+      t1 = new LinkedHashMap<>();
+      t2 = new LinkedHashMap<>();
       t1.put("foo", "1");
       t2.put("bar", "2");
 
@@ -63,7 +63,8 @@ public class ReferencesTest {
 
     // this is VERY BAD code
     // the map has itself as a key (no idea why it may be used except of a DoS attack)
-    LinkedHashMap f = new LinkedHashMap();
+    LinkedHashMap<Object, Object> f = new LinkedHashMap<>();
+    //noinspection CollectionAddedToSelf
     f.put(f, "a");
     f.put("g", root);
 
@@ -89,7 +90,7 @@ public class ReferencesTest {
         e.getMessage());
     }
     long time2 = System.currentTimeMillis();
-    float duration = (time2 - time1) / 1000;
+    float duration = (time2 - time1) / 1000f;
     assertTrue(duration < 1.0, "It should fail quickly. Time was " + duration + " seconds.");
   }
 
@@ -133,7 +134,7 @@ public class ReferencesTest {
         e.getMessage());
     }
     long time2 = System.currentTimeMillis();
-    float duration = (time2 - time1) / 1000;
+    float duration = (time2 - time1) / 1000f;
     assertTrue(duration < 1.0, "It should fail quickly. Time was " + duration + " seconds.");
   }
 }


### PR DESCRIPTION
I think the test is failing on CI because the test is performing worse than expected.

[Example failure](https://github.com/krzema12/snakeyaml-engine-kmp/actions/runs/7593971736/job/20685006620#step:5:284): 

```
ReferencesTest[jvm] > Parsing with aliases may take a lot of time, CPU and memory[jvm] FAILED
    org.opentest4j.AssertionFailedError: Time was 11.039 seconds. ==> expected: <true> but was: <false>
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at app//org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
        at app//org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
        at app//org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:214)
        at app//org.snakeyaml.engine.usecases.references.ReferencesTest.parseManyAliasesForCollections(ReferencesTest.java:113)
```

* Remove the num-of-cores logic regarding minDuration - 400ms seems fine.
* Increase max duration to 15 seconds - the exact timeout doesn't particularly matter, this test is always going to be slow.
* replace manual time measurement with Java 8 time utils
* add a JUnit timeout assertion