### PR TITLE
Revert "Remove custom Kotlin/Native repos"

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,36 @@ dependencyResolutionManagement {
             filter { includeGroup("com.yarnpkg") }
         }
 
+        // workaround for https://youtrack.jetbrains.com/issue/KT-51379
+        exclusiveContent {
+            forRepository {
+                ivy("https://download.jetbrains.com/kotlin/native/builds") {
+                    name = "Kotlin Native"
+                    patternLayout {
+
+                        // example download URLs:
+                        // https://download.jetbrains.com/kotlin/native/builds/releases/1.7.20/linux-x86_64/kotlin-native-prebuilt-linux-x86_64-1.7.20.tar.gz
+                        // https://download.jetbrains.com/kotlin/native/builds/releases/1.7.20/windows-x86_64/kotlin-native-prebuilt-windows-x86_64-1.7.20.zip
+                        // https://download.jetbrains.com/kotlin/native/builds/releases/1.7.20/macos-x86_64/kotlin-native-prebuilt-macos-x86_64-1.7.20.tar.gz
+                        listOf(
+                            "macos-x86_64",
+                            "macos-aarch64",
+                            "osx-x86_64",
+                            "osx-aarch64",
+                            "linux-x86_64",
+                            "windows-x86_64",
+                        ).forEach { os ->
+                            listOf("dev", "releases").forEach { stage ->
+                                artifact("$stage/[revision]/$os/[artifact]-[revision].[ext]")
+                            }
+                        }
+                    }
+                    metadataSources { artifact() }
+                }
+            }
+            filter { includeModuleByRegex(".*", ".*kotlin-native-prebuilt.*") }
+        }
+
         ivy("https://github.com/") {
             name = "GitHub Release"
             // used to download YAML Test Suite data from GitHub


### PR DESCRIPTION
Reverts krzema12/snakeyaml-engine-kmp#128

Apparently the artifacts are on Maven Central, but a custom repo is still required.