### PR TITLE
Tidy MarkedYamlEngineException

### DIFF
--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/ComposerException.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/ComposerException.kt
@@ -24,7 +24,7 @@ import kotlin.jvm.JvmOverloads
  * @param problemMark - the problem location
  */
 class ComposerException @JvmOverloads constructor(
-    problem: String?,
+    problem: String,
     problemMark: Mark?,
     context: String = "",
     contextMark: Mark? = null,

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/ConstructorException.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/ConstructorException.kt
@@ -26,7 +26,7 @@ import kotlin.jvm.JvmOverloads
 open class ConstructorException @JvmOverloads constructor(
     context: String?,
     contextMark: Mark?,
-    problem: String?,
+    problem: String,
     problemMark: Mark?,
     cause: Throwable? = null,
 ) : MarkedYamlEngineException(

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/MarkedYamlEngineException.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/MarkedYamlEngineException.kt
@@ -16,46 +16,27 @@ package org.snakeyaml.engine.v2.exceptions
 /**
  * Parsing exception when the marks are available
  *
- * @param cause - exception which was thrown
+ * @param problem A specific problem issue. Must always be present.
+ * @param problemMark Location of the specific problem.
+ * @param context General region of [problem]
+ * @param contextMark General region of [problemMark], e.g. the start of a problematic node
+ * @param cause exception which was thrown
  */
-open class MarkedYamlEngineException private constructor(
-    // can't override `message` property, so define a new one
-    // https://youtrack.jetbrains.com/issue/KT-43490/
-    private val readableError: String,
+open class MarkedYamlEngineException protected constructor(
+    val context: String?,
+    val contextMark: Mark?,
+    val problem: String,
+    val problemMark: Mark?,
     cause: Throwable? = null,
-) : YamlEngineException(readableError, cause) {
-
-    /**
-     * Parsing exception when the marks are available
-     *
-     * @param context - the context of the problem
-     * @param contextMark - position of the context
-     * @param problem - the issue
-     * @param problemMark - position of the issue
-     * @param cause - exception which was thrown
-     */
-    protected constructor(
-        context: String?,
-        contextMark: Mark?,
-        problem: String?,
-        problemMark: Mark?,
-        cause: Throwable? = null,
-    ) : this(
-        readableError = buildReadableError(
-            context = context,
-            contextMark = contextMark,
-            problem = problem,
-            problemMark = problemMark,
-        ),
-        cause = cause,
-    )
-
-    /**
-     * get readable error
-     *
-     * @return readable problem
-     */
-    override fun toString(): String = readableError
+) : YamlEngineException(
+    message = buildReadableError(
+        context = context,
+        contextMark = contextMark,
+        problem = problem,
+        problemMark = problemMark,
+    ),
+    cause = cause,
+) {
 
     companion object {
         private fun buildReadableError(

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/ParserException.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/ParserException.kt
@@ -24,7 +24,7 @@ import kotlin.jvm.JvmOverloads
  * @param problemMark Position of the `problem`. within the document.
  */
 class ParserException @JvmOverloads constructor(
-    problem: String?,
+    problem: String,
     contextMark: Mark?,
     context: String? = null,
     problemMark: Mark? = null,

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/ScannerException.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/exceptions/ScannerException.kt
@@ -16,7 +16,8 @@ package org.snakeyaml.engine.v2.exceptions
 import kotlin.jvm.JvmOverloads
 
 /**
- * Exception thrown by the [Scanner] implementations in case of malformed input.
+ * Exception thrown by the [Scanner][org.snakeyaml.engine.v2.scanner.Scanner]
+ * implementations in case of malformed input.
  *
  * @param context Part of the input document in which vicinity the problem occurred.
  * @param contextMark Position of the `context` within the document.

--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/scanner/ScannerImpl.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/scanner/ScannerImpl.kt
@@ -1,7 +1,5 @@
 package org.snakeyaml.engine.v2.scanner
 
-import kotlin.collections.set
-import kotlin.jvm.JvmInline
 import okio.Buffer
 import org.snakeyaml.engine.internal.utils.Character
 import org.snakeyaml.engine.internal.utils.appendCodePoint
@@ -15,6 +13,8 @@ import org.snakeyaml.engine.v2.exceptions.Mark
 import org.snakeyaml.engine.v2.exceptions.ScannerException
 import org.snakeyaml.engine.v2.exceptions.YamlEngineException
 import org.snakeyaml.engine.v2.tokens.*
+import kotlin.collections.set
+import kotlin.jvm.JvmInline
 
 
 /**
@@ -1791,10 +1791,10 @@ class ScannerImpl(
         if (reader.peek() == 0) {
             // A flow scalar cannot end with an end-of-stream
             throw ScannerException(
-                problem = "while scanning a quoted scalar",
-                problemMark = startMark,
-                context = "found unexpected end of stream",
-                contextMark = reader.getMark(),
+                problem = "found unexpected end of stream",
+                problemMark = reader.getMark(),
+                context = "while scanning a quoted scalar",
+                contextMark = startMark,
             )
         }
         // If we encounter a line break, scan it into our assembled string...
@@ -1908,7 +1908,7 @@ class ScannerImpl(
         // peak ahead to find end of whitespaces and the column at which it occurs
         var wsLength = 0
         var wsColumn = reader.column
-        while(true) {
+        while (true) {
             val c = reader.peek(wsLength)
             if (c == 0 || !CharConstants.NULL_BL_T_LINEBR.has(c)) {
                 break


### PR DESCRIPTION
Improvements for MarkedYamlEngineException, for use by Kaml in https://github.com/charleskorn/kaml/pull/507

- make 'problem' required (matches existing usages)
- make context/problems properties (they are used by Kaml)
- fix problem/context order of ScannerException in ScannerImpl

