### PR TITLE
add external link to Okio docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,11 @@ dokkatoo {
 
     dokkatooSourceSets.configureEach {
         includes.from(docsDir.file("modules.md"))
+
+        externalDocumentationLinks.register("okio") {
+            packageListUrl("https://square.github.io/okio/3.x/okio/okio/package-list")
+            url("https://square.github.io/okio/3.x/okio/")
+        }
     }
 
     pluginsConfiguration {


### PR DESCRIPTION
This PR adds an external link to the Okio docs, meaning that in our API reference docs, the Okio types will be clickable and linked to the Okio API reference docs.