### PR TITLE
Fix setting width greater than the default

### DIFF
--- a/src/commonMain/kotlin/org/snakeyaml/engine/v2/emitter/Emitter.kt
+++ b/src/commonMain/kotlin/org/snakeyaml/engine/v2/emitter/Emitter.kt
@@ -97,7 +97,7 @@ class Emitter(
     private val bestIndent: Int = if (opts.indent in VALID_INDENT_RANGE) opts.indent else DEFAULT_INDENT
     private val indicatorIndent: Int get() = opts.indicatorIndent
     private val indentWithIndicator: Boolean get() = opts.indentWithIndicator
-    private val bestWidth: Int = opts.width.coerceAtMost(MAX_WIDTH)
+    private val bestWidth: Int = if (opts.width > this.bestIndent * 2) opts.width else DEFAULT_WIDTH
     private val bestLineBreak: String get() = opts.bestLineBreak
     private val splitLines: Boolean get() = opts.isSplitLines
     private val maxSimpleKeyLength: Int get() = opts.maxSimpleKeyLength
@@ -1571,7 +1571,7 @@ class Emitter(
 
         private const val DEFAULT_INDENT = 2
 
-        private const val MAX_WIDTH = 80
+        private const val DEFAULT_WIDTH = 80
 
         private const val SPACE = " "
 

--- a/src/jvmTest/java/org/snakeyaml/engine/v2/emitter/EmitterTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/v2/emitter/EmitterTest.java
@@ -298,4 +298,21 @@ public class EmitterTest {
         "indicator indent range end must be one less than the indent range end"
     );
   }
+
+  @Test
+  public void testAllowSettingBigWidth() {
+    DumpSettingsBuilder builder =
+      DumpSettings.builder().setDefaultScalarStyle(ScalarStyle.DOUBLE_QUOTED)
+        .setDefaultFlowStyle(FlowStyle.FLOW).setWidth(1000);
+    Map<String, Object> map = new TreeMap<>();
+    map.put("12345", "1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 " +
+      "1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 " +
+      "1234567890 1234567890 1234567890 1234567890 1234567890 1234567890");
+
+    String output = dump(builder.build(), map);
+    assertEquals("{\"12345\": \"1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 " +
+      "1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 " +
+      "1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890\"}\n",
+      output);
+  }
 }


### PR DESCRIPTION
Resolves #152.

It looks like a coding error when porting snakeyaml-engine to Kotlin. The original project contains:
https://github.com/krzema12/snakeyaml-engine-kmp/blob/04614c75c124d30c58221ab11255c5d45d913a14/src/main/java/org/snakeyaml/engine/v2/emitter/Emitter.java#L213-L216

which I'm reimplementing in this PR.

BTW, there's no unit test for this behavior in snakeyaml-engine, and ideally we'd like to add it there as well. It would have prevented this regression.