### PR TITLE
Replace `.asSequence().asIterable()` with `Iterable {}`

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ComposeString.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ComposeString.kt
@@ -52,8 +52,10 @@ class ComposeString(
      * @return parsed root Nodes for all the specified YAML documents
      */
     fun composeAllFromString(yaml: String): Iterable<Node> =
-        Composer(
-            settings,
-            ParserImpl(settings, StreamReader(settings, yaml)),
-        ).asSequence().asIterable()
+        Iterable {
+            Composer(
+                settings,
+                ParserImpl(settings, StreamReader(settings, yaml)),
+            )
+        }
 }

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ParseString.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ParseString.kt
@@ -18,6 +18,7 @@ class ParseString(
      * @return parsed events
      */
     fun parseString(yaml: String): Iterable<Event> =
-        ParserImpl(settings, StreamReader(settings, yaml))
-            .asSequence().asIterable()
+        Iterable {
+            ParserImpl(settings, StreamReader(settings, yaml))
+        }
 }

--- a/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
+++ b/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
@@ -13,15 +13,15 @@
  */
 package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
-import java.io.InputStream
-import java.io.Reader
-import okio.source
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.api.YamlUnicodeReader
 import it.krzeminski.snakeyaml.engine.kmp.composer.Composer
 import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
 import it.krzeminski.snakeyaml.engine.kmp.parser.ParserImpl
 import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
+import okio.source
+import java.io.InputStream
+import java.io.Reader
 
 /**
  * Helper to compose input stream to Node
@@ -83,10 +83,12 @@ actual class Compose(
      * @return parsed root Nodes for all the specified YAML documents
      */
     fun composeAllFromReader(yaml: Reader): Iterable<Node> =
-        Composer(
-            settings,
-            ParserImpl(settings, StreamReader(settings, yaml.readText())),
-        ).asSequence().asIterable()
+        Iterable {
+            Composer(
+                settings,
+                ParserImpl(settings, StreamReader(settings, yaml.readText())),
+            )
+        }
 
     /**
      * Parse all YAML documents in a stream and produce corresponding representation trees.
@@ -98,10 +100,12 @@ actual class Compose(
      * @return parsed root Nodes for all the specified YAML documents
      */
     fun composeAllFromInputStream(yaml: InputStream): Iterable<Node> =
-        Composer(
-            settings,
-            ParserImpl(settings, StreamReader(settings, YamlUnicodeReader(yaml.source()))),
-        ).asSequence().asIterable()
+        Iterable {
+            Composer(
+                settings,
+                ParserImpl(settings, StreamReader(settings, YamlUnicodeReader(yaml.source()))),
+            )
+        }
 
     /**
      * Parse all YAML documents in a stream and produce corresponding representation trees.

--- a/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
+++ b/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
@@ -13,14 +13,14 @@
  */
 package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
-import java.io.InputStream
-import java.io.Reader
-import okio.source
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.api.YamlUnicodeReader
 import it.krzeminski.snakeyaml.engine.kmp.events.Event
 import it.krzeminski.snakeyaml.engine.kmp.parser.ParserImpl
 import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
+import okio.source
+import java.io.InputStream
+import java.io.Reader
 
 /**
  * Read the input stream and parse the content into events (opposite for Present or Emit)
@@ -41,8 +41,9 @@ actual class Parse actual constructor(
      * @return parsed events
      */
     fun parseInputStream(yaml: InputStream): Iterable<Event> =
-        ParserImpl(settings, StreamReader(settings, YamlUnicodeReader(yaml.source())))
-            .asSequence().asIterable()
+        Iterable {
+            ParserImpl(settings, StreamReader(settings, YamlUnicodeReader(yaml.source())))
+        }
 
     /**
      * Parse a YAML stream and produce parsing events. Since the encoding is already known the BOM
@@ -54,8 +55,9 @@ actual class Parse actual constructor(
      * @return parsed events
      */
     fun parseReader(yaml: Reader): Iterable<Event> =
-        ParserImpl(settings, StreamReader(settings, yaml.readText()))
-            .asSequence().asIterable()
+        Iterable {
+            ParserImpl(settings, StreamReader(settings, yaml.readText()))
+        }
 
     /**
      * Parse a YAML stream and produce parsing events.


### PR DESCRIPTION
Using `Iterable {}` avoids creating an unnecessary Sequence instance