### PR TITLE
Fix scanning for tabs in plain-spaces

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ScannerImpl.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ScannerImpl.kt
@@ -1964,7 +1964,7 @@ class ScannerImpl(
      */
     private fun scanPlainSpaces(): String {
         var length = 0
-        while (reader.peek(length) == ' '.code || reader.peek(length) == '\t'.code) {
+        while (reader.peek(length).toChar() in " \t") {
             length++
         }
         val whitespaces = reader.prefixForward(length)
@@ -1979,7 +1979,7 @@ class ScannerImpl(
         } else {
             val breaks = StringBuilder()
             while (true) {
-                if (reader.peek() == ' '.code) {
+                if (reader.peek().toChar() in " \t") {
                     reader.forward()
                 } else {
                     val lbOpt = scanLineBreak()

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/SuiteUtils.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/SuiteUtils.kt
@@ -60,7 +60,6 @@ internal object SuiteUtils {
     val deviationsWithError: Set<YamlTestData.Id> = setOf(
         //region originally copied from SnakeYAML
         // https://github.com/snakeyaml/snakeyaml-engine/blob/5a35e1fe7f780d1405d5a03470f9f13d32b1638a/src/test/java/org/snakeyaml/engine/usecases/external_test_suite/SuiteUtils.java#L35-L40
-        "2JQS",
         "3RLN-01",
         "3RLN-04",
         "4MUZ",
@@ -72,11 +71,9 @@ internal object SuiteUtils {
         "5T43",
         "6BCT",
         "6HB6",
-        "6M2F",
         "7Z25",
         "9SA2",
         "A2M4",
-        "CFD4",
         "DBG4",
         "DC7X",
         "DE56-02",
@@ -85,7 +82,6 @@ internal object SuiteUtils {
         "FP8R",
         "FRK4",
         "HM87-00",
-        "HS5T",
         "HWV9",
         "J3BT",
         "K3WX",
@@ -95,23 +91,29 @@ internal object SuiteUtils {
         "M2N8-00",
         "M7A3",
         "MUS6-03",
-        "NB6Z",
-        "NHX8",
         "NJ66",
-        "NKF9",
         "Q5MG",
         "QT73",
-        "S3PD",
         "SM9W-01",
         "UKK6-00",
         "UT92",
-        "UV7Q",
         "VJP3-01",
         "W4TN",
         "W5VH",
         "WZ62",
         "Y79Y-002",
         "Y79Y-010",
+        //region empty-key cases
+        // These cases use an empty node as a key. Use of empty keys is discouraged and might be removed
+        // in the next YAML version. In short: don't bother trying to fix these tests.
+        "2JQS",
+        "6M2F",
+        "CFD4",
+        "FRK4",
+        "NHX8",
+        "NKF9",
+        "S3PD",
+        //endregion
         //endregion
 
         //region Additional cases that SnakeYAML-Java also doesn't pass
@@ -120,8 +122,6 @@ internal object SuiteUtils {
         "6CA3",        // https://matrix.yaml.info/details/6CA3.html
         "DK95:00",     // https://matrix.yaml.info/details/DK95:00.html
         "DK95:03",     // https://matrix.yaml.info/details/DK95:03.html
-        "DK95:04",     // https://matrix.yaml.info/details/DK95:04.html
-        "DK95:05",     // https://matrix.yaml.info/details/DK95:05.html
         "DK95:07",     // https://matrix.yaml.info/details/DK95:07.html
         //endregion
     ).mapToYamlTestDataId()

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/external_test_suite/SuiteUtils.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/external_test_suite/SuiteUtils.java
@@ -32,12 +32,12 @@ public class SuiteUtils {
 
   public static final List<String> deviationsWithSuccess =
       Lists.newArrayList("9JBA", "CVW2", "9C9N", "SU5Z", "QB6E");
-  public static final List<String> deviationsWithError = Lists.newArrayList("HWV9", "NB6Z",
+  public static final List<String> deviationsWithError = Lists.newArrayList("HWV9",
       "VJP3-01", "KH5V-01", "5MUD", "9SA2", "QT73", "4MUZ", "CFD4", "NJ66", "NKF9", "K3WX", "5T43",
       "3RLN-01", "SM9W-01", "3RLN-04", "DE56-02", "DE56-03", "4MUZ-00", "4MUZ-02", "4MUZ-01",
       "UKK6-00", "K54U", "Y79Y-002", "Y79Y-010", "KZN9", "2JQS", "6M2F", "S3PD", "FRK4", "NHX8",
-      "M2N8-00", "MUS6-03", "6BCT", "6HB6", "Q5MG", "DBG4", "M7A3", "DK3J", "W5VH", "58MP", "UV7Q",
-      "HM87-00", "DC7X", "A2M4", "J3BT", "HS5T", "UT92", "W4TN", "FP8R", "WZ62", "7Z25");
+      "M2N8-00", "MUS6-03", "6BCT", "6HB6", "Q5MG", "DBG4", "M7A3", "DK3J", "W5VH", "58MP",
+      "HM87-00", "DC7X", "A2M4", "J3BT", "UT92", "W4TN", "FP8R", "WZ62", "7Z25");
 
 
   public static final String FOLDER_NAME = "src/jvmTest/resources/comprehensive-test-suite-data";


### PR DESCRIPTION
- Always permit spaces and tabs when scanning plain spaces, not just the initial whitespace.
- Add note regarding empty-key test-suite cases