### PR TITLE
Refactor Parse

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
@@ -1,10 +1,29 @@
 package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
-import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.events.Event
+import okio.Source
 
-expect class Parse(
-    settings: LoadSettings
-) {
+expect class Parse {
+    /**
+     * Parse a YAML string and produce parsing events.
+     *
+     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
+     *
+     * @param string YAML document(s). The BOM must not be present (it will be parsed as content)
+     * @return parsed events
+     */
+    fun parse(string: String): Iterable<Event>
+
+    /**
+     * Parse a YAML stream and produce parsing events.
+     *
+     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
+     *
+     * @param source YAML document(s). The BOM must not be present (it will be parsed as content)
+     * @return parsed events
+     */
+    fun parse(source: Source): Iterable<Event>
+
+    @Deprecated("renamed", ReplaceWith("parse(yaml)"))
     fun parseString(yaml: String): Iterable<Event>
 }

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
@@ -1,9 +1,12 @@
 package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
+import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.events.Event
 import okio.Source
 
-expect class Parse {
+expect class Parse(
+    settings: LoadSettings,
+) {
     /**
      * Parse a YAML string and produce parsing events.
      *

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ParseCommon.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ParseCommon.kt
@@ -1,0 +1,21 @@
+package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
+
+import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
+import it.krzeminski.snakeyaml.engine.kmp.events.Event
+import it.krzeminski.snakeyaml.engine.kmp.parser.ParserImpl
+import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
+import okio.Buffer
+import okio.Source
+
+internal class ParseCommon  (
+    private val settings: LoadSettings,
+) {
+    fun parse(string: String): Iterable<Event> =
+        parse(Buffer().writeUtf8(string))
+
+    fun parse(source: Source): Iterable<Event> =
+        Iterable {
+            val reader = StreamReader(stream = source, loadSettings = settings)
+            ParserImpl(settings, reader)
+        }
+}

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ParseString.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ParseString.kt
@@ -2,12 +2,12 @@ package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.events.Event
-import it.krzeminski.snakeyaml.engine.kmp.parser.ParserImpl
-import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
 
+@Deprecated("No longer used", ReplaceWith("it.krzeminski.snakeyaml.engine.kmp.api.lowlevel.Parse"))
 class ParseString(
-    private val settings: LoadSettings,
+    settings: LoadSettings,
 ) {
+    private val parse = ParseCommon(settings)
 
     /**
      * Parse a YAML stream and produce parsing events.
@@ -17,8 +17,5 @@ class ParseString(
      * @param yaml - YAML document(s). The BOM must not be present (it will be parsed as content)
      * @return parsed events
      */
-    fun parseString(yaml: String): Iterable<Event> =
-        Iterable {
-            ParserImpl(settings, StreamReader(settings, yaml))
-        }
+    fun parseString(yaml: String): Iterable<Event> = parse.parse(yaml)
 }

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/SuiteUtils.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/SuiteUtils.kt
@@ -13,7 +13,7 @@ internal object SuiteUtils {
         val settings = LoadSettings.builder().setLabel(data.label).build()
 
         return try {
-            ParseResult(Parse(settings).parseString(data.inYaml).toList())
+            ParseResult(Parse(settings).parse(data.inYaml).toList())
         } catch (e: YamlEngineException) {
             ParseResult(null, e)
         }

--- a/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
+++ b/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
@@ -4,7 +4,7 @@ import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.events.Event
 import okio.Source
 
-actual class Parse(
+actual class Parse actual constructor(
     settings: LoadSettings,
 ) {
     private val common = ParseCommon(settings)

--- a/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
+++ b/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
@@ -2,20 +2,17 @@ package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.events.Event
+import okio.Source
 
-actual class Parse actual constructor(
+actual class Parse(
     settings: LoadSettings,
 ) {
-    private val parseString = ParseString(settings)
+    private val common = ParseCommon(settings)
 
-    /**
-     * Parse a YAML stream and produce parsing events.
-     *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s). The BOM must not be present (it will be parsed as content)
-     * @return parsed events
-     */
-    actual fun parseString(yaml: String): Iterable<Event> =
-        parseString.parseString(yaml)
+    actual fun parse(string: String): Iterable<Event> = common.parse(string)
+
+    actual fun parse(source: Source): Iterable<Event> = common.parse(source)
+
+    @Deprecated("renamed", ReplaceWith("parse(yaml)"))
+    actual fun parseString(yaml: String): Iterable<Event> = parse(yaml)
 }

--- a/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
+++ b/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
@@ -24,8 +24,8 @@ import java.io.Reader
  * Read the input stream and parse the content into events (opposite for Present or Emit)
  * @param settings - configuration
  */
-actual class Parse(
-    private val settings: LoadSettings,
+actual class Parse actual constructor(
+    settings: LoadSettings,
 ) {
     private val common = ParseCommon(settings)
 

--- a/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
+++ b/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
@@ -14,10 +14,8 @@
 package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
-import it.krzeminski.snakeyaml.engine.kmp.api.YamlUnicodeReader
 import it.krzeminski.snakeyaml.engine.kmp.events.Event
-import it.krzeminski.snakeyaml.engine.kmp.parser.ParserImpl
-import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
+import okio.Source
 import okio.source
 import java.io.InputStream
 import java.io.Reader
@@ -26,24 +24,14 @@ import java.io.Reader
  * Read the input stream and parse the content into events (opposite for Present or Emit)
  * @param settings - configuration
  */
-actual class Parse actual constructor(
+actual class Parse(
     private val settings: LoadSettings,
 ) {
-    private val parseString = ParseString(settings)
+    private val common = ParseCommon(settings)
 
-    /**
-     * Parse a YAML stream and produce parsing events.
-     *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s). Default encoding is UTF-8. The BOM must be present if the
-     * encoding is UTF-16 or UTF-32
-     * @return parsed events
-     */
-    fun parseInputStream(yaml: InputStream): Iterable<Event> =
-        Iterable {
-            ParserImpl(settings, StreamReader(settings, YamlUnicodeReader(yaml.source())))
-        }
+    actual fun parse(string: String): Iterable<Event> = common.parse(string)
+
+    actual fun parse(source: Source): Iterable<Event> = common.parse(source)
 
     /**
      * Parse a YAML stream and produce parsing events. Since the encoding is already known the BOM
@@ -51,22 +39,28 @@ actual class Parse actual constructor(
      *
      * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
      *
-     * @param yaml - YAML document(s).
+     * @param reader YAML document(s).
      * @return parsed events
      */
-    fun parseReader(yaml: Reader): Iterable<Event> =
-        Iterable {
-            ParserImpl(settings, StreamReader(settings, yaml.readText()))
-        }
+    fun parse(reader: Reader): Iterable<Event> = parse(reader.readText())
 
     /**
      * Parse a YAML stream and produce parsing events.
      *
      * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
      *
-     * @param yaml - YAML document(s). The BOM must not be present (it will be parsed as content)
+     * @param inputStream YAML document(s). Default encoding is UTF-8. The BOM must be present if the
+     * encoding is UTF-16 or UTF-32
      * @return parsed events
      */
-    actual fun parseString(yaml: String): Iterable<Event> =
-        parseString.parseString(yaml)
+    fun parse(inputStream: InputStream): Iterable<Event> = parse(inputStream.source())
+
+    @Deprecated("renamed", ReplaceWith("parse(yaml)"))
+    actual fun parseString(yaml: String): Iterable<Event> = parse(yaml)
+
+    @Deprecated("renamed", ReplaceWith("parse(yaml)"))
+    fun parseInputStream(yaml: InputStream): Iterable<Event> = parse(yaml)
+
+    @Deprecated("renamed", ReplaceWith("parse(yaml)"))
+    fun parseReader(yaml: Reader): Iterable<Event> = parse(yaml)
 }

--- a/src/jvmTest/java/org/snakeyaml/engine/issues/issue149/GlobalDirectivesTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/issues/issue149/GlobalDirectivesTest.java
@@ -34,7 +34,7 @@ public class GlobalDirectivesTest {
   Iterable<Event> yamlToEvents(@Language("file-reference") final String resourceName) {
     InputStream input = TestUtils.getResourceAsStream(resourceName);
     Parse parser = new Parse(LoadSettings.builder().build());
-    return parser.parseInputStream(input);
+    return parser.parse(input);
   }
 
   @Test

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/external_test_suite/ParseSuiteTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/external_test_suite/ParseSuiteTest.java
@@ -43,7 +43,7 @@ class ParseSuiteTest {
   void runOne() {
     SuiteData data = SuiteUtils.getOne("S98Z");
     LoadSettings settings = LoadSettings.builder().setLabel(data.getLabel()).build();
-    Iterable<Event> iterable = new Parse(settings).parseString(data.getInput());
+    Iterable<Event> iterable = new Parse(settings).parse(data.getInput());
     for (Event event : iterable) {
       assertNotNull(event);
       System.out.println(event);

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/external_test_suite/SuiteUtils.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/external_test_suite/SuiteUtils.java
@@ -82,7 +82,7 @@ public class SuiteUtils {
     List<Event> list = new ArrayList();
     try {
       LoadSettings settings = LoadSettings.builder().setLabel(data.getLabel()).build();
-      Iterable<Event> iterable = new Parse(settings).parseString(data.getInput());
+      Iterable<Event> iterable = new Parse(settings).parse(data.getInput());
       iterable.forEach(event -> list.add(event));
     } catch (YamlEngineException e) {
       error = e;

--- a/src/jvmTest/java/org/snakeyaml/engine/v2/api/lowlevel/ParseEmitTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/v2/api/lowlevel/ParseEmitTest.java
@@ -67,7 +67,7 @@ class ParseEmitTest {
   void yamlToYaml(final InputStream in, final PrintStream out) throws IOException {
     Parse parser = new Parse(LoadSettings.builder().build());
     Emitter emitter = new Emitter(DumpSettings.builder().build(), new MyDumperWriter(out));
-    for (Event event : parser.parseInputStream(in)) {
+    for (Event event : parser.parse(in)) {
       emitter.emit(event);
     }
   }

--- a/src/jvmTest/java/org/snakeyaml/engine/v2/api/lowlevel/ParseTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/v2/api/lowlevel/ParseTest.java
@@ -36,7 +36,7 @@ class ParseTest {
   @Test
   void parseEmptyReader() throws IOException {
     Parse parse = new Parse(LoadSettings.builder().build());
-    Iterable<Event> events = parse.parseReader(CharSource.wrap("").openStream());
+    Iterable<Event> events = parse.parse(CharSource.wrap("").openStream());
     List<Event> list = Lists.newArrayList(events);
     assertEquals(2, list.size());
     TestUtils.compareEvents(Lists.newArrayList(new StreamStartEvent(), new StreamEndEvent()), list);
@@ -45,7 +45,7 @@ class ParseTest {
   @Test
   void parseEmptyInputStream() {
     Parse parse = new Parse(LoadSettings.builder().build());
-    Iterable<Event> events = parse.parseInputStream(new ByteArrayInputStream("".getBytes()));
+    Iterable<Event> events = parse.parse(new ByteArrayInputStream("".getBytes()));
     List<Event> list = Lists.newArrayList(events);
     assertEquals(2, list.size());
     TestUtils.compareEvents(Lists.newArrayList(new StreamStartEvent(), new StreamEndEvent()), list);

--- a/src/nativeMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
+++ b/src/nativeMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
@@ -4,7 +4,7 @@ import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.events.Event
 import okio.Source
 
-actual class Parse(
+actual class Parse actual constructor(
     settings: LoadSettings,
 ) {
     private val common = ParseCommon(settings)

--- a/src/nativeMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
+++ b/src/nativeMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Parse.kt
@@ -2,20 +2,17 @@ package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.events.Event
+import okio.Source
 
-actual class Parse actual constructor(
+actual class Parse(
     settings: LoadSettings,
 ) {
-    private val parseString = ParseString(settings)
+    private val common = ParseCommon(settings)
 
-    /**
-     * Parse a YAML stream and produce parsing events.
-     *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s). The BOM must not be present (it will be parsed as content)
-     * @return parsed events
-     */
-    actual fun parseString(yaml: String): Iterable<Event> =
-        parseString.parseString(yaml)
+    actual fun parse(string: String): Iterable<Event> = common.parse(string)
+
+    actual fun parse(source: Source): Iterable<Event> = common.parse(source)
+
+    @Deprecated("renamed", ReplaceWith("parse(yaml)"))
+    actual fun parseString(yaml: String): Iterable<Event> = parse(yaml)
 }


### PR DESCRIPTION
- Create ParseCommon, for shared commonMain Parsing code
- Rename functions, so they're overloaded based on the arg type
- Deprecate unnecessary ParseString
- De-duplicate/tidy KDoc