### PR TITLE
Refactor Compose

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
@@ -13,6 +13,7 @@
  */
 package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
+import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
 import okio.Source
 
@@ -21,7 +22,7 @@ import okio.Source
  *
  * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
  */
-expect class Compose {
+expect class Compose(settings: LoadSettings) {
     /**
      * Parse a YAML stream and produce a single [Node], if available in [source].
      *

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
@@ -14,30 +14,48 @@
 package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
 import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
+import okio.Source
 
 /**
- * Helper to compose input stream to Node
+ * Compose input sources to [Node]s.
+ *
+ * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
  */
 expect class Compose {
+    /**
+     * Parse a YAML stream and produce a single [Node], if available in [source].
+     *
+     * @param source YAML document(s).
+     */
+    fun compose(source: Source): Node?
 
     /**
      * Parse a YAML stream and produce [Node]
      *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s).
-     * @return parsed [Node] if available
+     * @param string YAML document(s).
+     * @return parsed [Node], if available in [string].
      */
-    fun composeString(yaml: String): Node?
-
+    fun compose(string: String): Node?
 
     /**
      * Parse all YAML documents in a stream and produce corresponding representation trees.
      *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s).
-     * @return parsed root Nodes for all the specified YAML documents
+     * @param source YAML document(s).
+     * @return parsed root [Node]s for all YAML documents in [source].
      */
+    fun composeAll(source: Source): Iterable<Node>
+
+    /**
+     * Parse all YAML documents in a stream and produce corresponding representation trees.
+     *
+     * @param string YAML document(s).
+     * @return parsed root [Node]s for all YAML documents in [string].
+     */
+    fun composeAll(string: String): Iterable<Node>
+
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
+    fun composeString(yaml: String): Node?
+
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
     fun composeAllFromString(yaml: String): Iterable<Node>
 }

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ComposeCommon.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ComposeCommon.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, SnakeYAML
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
+
+import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
+import it.krzeminski.snakeyaml.engine.kmp.composer.Composer
+import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
+import it.krzeminski.snakeyaml.engine.kmp.parser.ParserImpl
+import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
+import okio.Buffer
+import okio.Source
+
+/**
+ * Kotlin Common implementations of [Compose] functions.
+ */
+internal class ComposeCommon(
+    private val settings: LoadSettings,
+) {
+    /** @see Compose.compose */
+    fun compose(source: Source): Node? = composer(source).getSingleNode()
+
+    /** @see Compose.compose */
+    fun compose(string: String): Node? = compose(Buffer().writeUtf8(string))
+
+    /** @see Compose.composeAll */
+    fun composeAll(source: Source): Iterable<Node> = Iterable { composer(source) }
+
+    /** @see Compose.composeAll */
+    fun composeAll(string: String): Iterable<Node> = composeAll(Buffer().writeUtf8(string))
+
+    private fun composer(source: Source): Composer {
+        val reader = StreamReader(stream = source, loadSettings = settings)
+        val parser = ParserImpl(settings = settings, reader = reader)
+        return Composer(settings = settings, parser = parser)
+    }
+}

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ComposeString.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/ComposeString.kt
@@ -22,8 +22,9 @@ import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
 /**
  * Helper to compose strings to [Node]s.
  *
- * @param settings - configuration
+ * @param settings configuration
  */
+@Deprecated("Converted to common it.krzeminski.snakeyaml.engine.kmp.api.lowlevel.Compose", ReplaceWith("it.krzeminski.snakeyaml.engine.kmp.api.lowlevel.Compose"))
 class ComposeString(
     private val settings: LoadSettings,
 ) {
@@ -33,29 +34,30 @@ class ComposeString(
      *
      * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
      *
-     * @param yaml - YAML document(s).
-     * @return parsed [Node] if available
+     * @param string YAML document(s).
+     * @return parsed [Node], if available in [string].
      */
-    fun composeString(yaml: String): Node? =
-        Composer(
-            settings,
-            ParserImpl(settings, StreamReader(settings, yaml)),
-        ).getSingleNode()
+    fun compose(string: String): Node? = composer(string).getSingleNode()
 
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
+    fun composeString(yaml: String): Node? = compose(yaml)
 
     /**
      * Parse all YAML documents in a stream and produce corresponding representation trees.
      *
      * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
      *
-     * @param yaml - YAML document(s).
-     * @return parsed root Nodes for all the specified YAML documents
+     * @param string YAML document(s).
+     * @return parsed root [Node]s for all YAML documents in [string].
      */
-    fun composeAllFromString(yaml: String): Iterable<Node> =
-        Iterable {
-            Composer(
-                settings,
-                ParserImpl(settings, StreamReader(settings, yaml)),
-            )
-        }
+    fun composeAll(string: String): Iterable<Node> = Iterable { composer(string) }
+
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
+    fun composeAllFromString(yaml: String): Iterable<Node> = composeAll(yaml)
+
+    private fun composer(yaml: String): Composer {
+        val reader = StreamReader(stream = yaml, loadSettings = settings)
+        val parser = ParserImpl(settings, reader)
+        return Composer(settings, parser)
+    }
 }

--- a/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
+++ b/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
@@ -2,33 +2,22 @@ package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
+import okio.Source
 
-/**
- * Helper to compose input stream to Node
- * @param settings - configuration
- */
 actual class Compose(settings: LoadSettings) {
+    private val common = ComposeCommon(settings)
 
-    private val composeString = ComposeString(settings)
+    actual fun compose(source: Source): Node? = common.compose(source)
 
-    /**
-     * Parse a YAML stream and produce [Node]
-     *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s).
-     * @return parsed [Node] if available
-     */
-    actual fun composeString(yaml: String): Node? = composeString.composeString(yaml)
+    actual fun compose(string: String): Node? = common.compose(string)
 
-    /**
-     * Parse all YAML documents in a stream and produce corresponding representation trees.
-     *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s).
-     * @return parsed root Nodes for all the specified YAML documents
-     */
-    actual fun composeAllFromString(yaml: String): Iterable<Node> =
-        composeString.composeAllFromString(yaml)
+    actual fun composeAll(source: Source): Iterable<Node> = common.composeAll(source)
+
+    actual fun composeAll(string: String): Iterable<Node> = common.composeAll(string)
+
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
+    actual fun composeString(yaml: String): Node? = compose(yaml)
+
+    @Deprecated("renamed", ReplaceWith("composeAll(yaml)"))
+    actual fun composeAllFromString(yaml: String): Iterable<Node> = composeAll(yaml)
 }

--- a/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
+++ b/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
@@ -4,7 +4,9 @@ import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
 import okio.Source
 
-actual class Compose(settings: LoadSettings) {
+actual class Compose actual constructor(
+    settings: LoadSettings,
+) {
     private val common = ComposeCommon(settings)
 
     actual fun compose(source: Source): Node? = common.compose(source)

--- a/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
+++ b/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
@@ -20,7 +20,9 @@ import okio.source
 import java.io.InputStream
 import java.io.Reader
 
-actual class Compose(settings: LoadSettings) {
+actual class Compose actual constructor(
+    settings: LoadSettings,
+) {
     private val common = ComposeCommon(settings)
 
     actual fun compose(source: Source): Node? = common.compose(source)

--- a/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
+++ b/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
@@ -14,107 +14,73 @@
 package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
-import it.krzeminski.snakeyaml.engine.kmp.api.YamlUnicodeReader
-import it.krzeminski.snakeyaml.engine.kmp.composer.Composer
 import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
-import it.krzeminski.snakeyaml.engine.kmp.parser.ParserImpl
-import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
+import okio.Source
 import okio.source
 import java.io.InputStream
 import java.io.Reader
 
-/**
- * Helper to compose input stream to Node
- * @param settings - configuration
- */
-actual class Compose(
-    private val settings: LoadSettings,
-) {
+actual class Compose(settings: LoadSettings) {
+    private val common = ComposeCommon(settings)
 
-    private val composeString = ComposeString(settings)
+    actual fun compose(source: Source): Node? = common.compose(source)
 
-    /**
-     * Parse a YAML stream and produce [Node]
-     *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s). Since the encoding is already known the BOM must not be present
-     * (it will be parsed as content)
-     * @return parsed [Node] if available
-     */
-    fun composeReader(yaml: Reader): Node? =
-        Composer(
-            settings,
-            ParserImpl(settings, StreamReader(settings, yaml.readText())),
-        ).getSingleNode()
+    actual fun compose(string: String): Node? = common.compose(string)
+
+    actual fun composeAll(source: Source): Iterable<Node> = common.composeAll(source)
+
+    actual fun composeAll(string: String): Iterable<Node> = common.composeAll(string)
 
     /**
-     * Parse a YAML stream and produce [Node]
+     * Parse a YAML stream and produce a single [Node], if available in [reader].
      *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s). Default encoding is UTF-8. The BOM must be present if the
-     * encoding is UTF-16 or UTF-32
-     * @return parsed [Node] if available
+     * @param inputStream YAML document(s).
      */
-    fun composeInputStream(yaml: InputStream): Node? =
-        Composer(
-            settings,
-            ParserImpl(settings, StreamReader(settings, YamlUnicodeReader(yaml.source()))),
-        ).getSingleNode()
+    fun compose(inputStream: InputStream): Node? = compose(inputStream.source())
+
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
+    fun composeInputStream(yaml: InputStream): Node? = compose(yaml)
+
 
     /**
-     * Parse a YAML stream and produce [Node]
+     * Parse a YAML stream and produce a single [Node], if available in [reader].
      *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s).
-     * @return parsed [Node] if available
+     * @param reader YAML document(s).
      */
-    actual fun composeString(yaml: String): Node? = composeString.composeString(yaml)
+    fun compose(reader: Reader): Node? = compose(reader.readText())
 
-    // Compose all documents
-    /**
-     * Parse all YAML documents in a stream and produce corresponding representation trees.
-     *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml stream of YAML documents
-     * @return parsed root Nodes for all the specified YAML documents
-     */
-    fun composeAllFromReader(yaml: Reader): Iterable<Node> =
-        Iterable {
-            Composer(
-                settings,
-                ParserImpl(settings, StreamReader(settings, yaml.readText())),
-            )
-        }
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
+    fun composeReader(yaml: Reader): Node? = compose(yaml)
 
     /**
      * Parse all YAML documents in a stream and produce corresponding representation trees.
      *
      * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
      *
-     * @param yaml - YAML document(s). Default encoding is UTF-8. The BOM must be present if the
-     * encoding is UTF-16 or UTF-32
-     * @return parsed root Nodes for all the specified YAML documents
+     * @param inputStream stream of YAML documents
+     * @return parsed root [Node]s for all YAML documents in [inputStream].
      */
-    fun composeAllFromInputStream(yaml: InputStream): Iterable<Node> =
-        Iterable {
-            Composer(
-                settings,
-                ParserImpl(settings, StreamReader(settings, YamlUnicodeReader(yaml.source()))),
-            )
-        }
+    fun composeAll(inputStream: InputStream): Iterable<Node> = composeAll(inputStream.source())
+
+    @Deprecated("renamed", ReplaceWith("composeAll(yaml)"))
+    fun composeAllFromInputStream(yaml: InputStream): Iterable<Node> = composeAll(yaml)
 
     /**
      * Parse all YAML documents in a stream and produce corresponding representation trees.
      *
      * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
      *
-     * @param yaml - YAML document(s).
-     * @return parsed root Nodes for all the specified YAML documents
+     * @param reader stream of YAML documents
+     * @return parsed root [Node]s for all YAML documents in [reader].
      */
-    actual fun composeAllFromString(yaml: String): Iterable<Node> =
-        composeString.composeAllFromString(yaml)
+    fun composeAll(reader: Reader): Iterable<Node> = composeAll(reader.readText())
+
+    @Deprecated("renamed", ReplaceWith("composeAll(yaml)"))
+    fun composeAllFromReader(yaml: Reader): Iterable<Node> = composeAll(yaml)
+
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
+    actual fun composeString(yaml: String): Node? = compose(yaml)
+
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
+    actual fun composeAllFromString(yaml: String): Iterable<Node> = composeAll(yaml)
 }

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/env/EnvTagTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/env/EnvTagTest.java
@@ -29,7 +29,7 @@ public class EnvTagTest {
   @Test
   public void testImplicitResolverForEnvConstructor() {
     Compose loader = new Compose(LoadSettings.builder().build());
-    Node loaded = loader.composeString("${PATH}");
+    Node loaded = loader.compose("${PATH}");
     assertEquals(Tag.ENV_TAG, loaded.getTag());
   }
 }

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/external_test_suite/ComposeSuiteTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/external_test_suite/ComposeSuiteTest.java
@@ -54,7 +54,7 @@ class ComposeSuiteTest {
     List<Node> list = new ArrayList();
     try {
       LoadSettings settings = LoadSettings.builder().setLabel(data.getLabel()).build();
-      Iterable<Node> iterable = new Compose(settings).composeAllFromString(data.getInput());
+      Iterable<Node> iterable = new Compose(settings).composeAll(data.getInput());
       iterable.forEach(event -> list.add(event));
     } catch (YamlEngineException e) {
       error = e;
@@ -67,7 +67,7 @@ class ComposeSuiteTest {
   void runOne() {
     SuiteData data = SuiteUtils.getOne("C4HZ");
     LoadSettings settings = LoadSettings.builder().setLabel(data.getLabel()).build();
-    Node node = new Compose(settings).composeString(data.getInput());
+    Node node = new Compose(settings).compose(data.getInput());
     assertNotNull(node);
     // System.out.println(node);
   }

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/external_test_suite/EmitSuiteTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/external_test_suite/EmitSuiteTest.java
@@ -46,7 +46,7 @@ class EmitSuiteTest {
         // emit without errors
         String yaml = emit.emitToString(result.getEvents().iterator());
         // eat your own dog food
-        new Compose(LoadSettings.builder().build()).composeAllFromString(yaml);
+        new Compose(LoadSettings.builder().build()).composeAll(yaml);
       }
     }
   }

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/references/DumpAnchorTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/references/DumpAnchorTest.java
@@ -36,7 +36,7 @@ public class DumpAnchorTest {
   public void test_anchor_test() {
     String str = TestUtils.getResource("/anchor/issue481.yaml");
     Compose compose = new Compose(LoadSettings.builder().build());
-    Node node = compose.composeReader(new StringReader(str));
+    Node node = compose.compose(new StringReader(str));
 
     DumpSettings setting = DumpSettings.builder().setDefaultFlowStyle(FlowStyle.BLOCK)
         .setAnchorGenerator(node1 -> node1.getAnchor()).build();

--- a/src/jvmTest/java/org/snakeyaml/engine/v2/api/OptionalMarksTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/v2/api/OptionalMarksTest.java
@@ -34,7 +34,7 @@ class OptionalMarksTest {
     SuiteData data = SuiteUtils.getOne("2AUY");
     LoadSettings settings =
         LoadSettings.builder().setLabel(data.getLabel()).setUseMarks(false).build();
-    Node node = new Compose(settings).composeString("{a: 4}");
+    Node node = new Compose(settings).compose("{a: 4}");
     assertNotNull(node);
   }
 
@@ -45,7 +45,7 @@ class OptionalMarksTest {
     LoadSettings settings =
         LoadSettings.builder().setLabel(data.getLabel()).setUseMarks(true).build();
     ParserException exception =
-        assertThrows(ParserException.class, () -> new Compose(settings).composeString("{a: 4}}"));
+        assertThrows(ParserException.class, () -> new Compose(settings).compose("{a: 4}}"));
     assertTrue(exception.getMessage().contains("line 1, column 7:"),
         "The error must contain Mark data.");
   }
@@ -58,7 +58,7 @@ class OptionalMarksTest {
     LoadSettings settings =
         LoadSettings.builder().setLabel(data.getLabel()).setUseMarks(false).build();
     ParserException exception =
-        assertThrows(ParserException.class, () -> new Compose(settings).composeString("{a: 4}}"));
+        assertThrows(ParserException.class, () -> new Compose(settings).compose("{a: 4}}"));
     assertEquals("expected '<document start>', but found '}'\n", exception.getMessage());
   }
 }

--- a/src/jvmTest/java/org/snakeyaml/engine/v2/api/lowlevel/ComposeTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/v2/api/lowlevel/ComposeTest.java
@@ -32,28 +32,28 @@ class ComposeTest {
   @Test
   void composeEmptyReader() throws IOException {
     Compose compose = new Compose(LoadSettings.builder().build());
-    Node node = compose.composeReader(CharSource.wrap("").openStream());
+    Node node = compose.compose(CharSource.wrap("").openStream());
     assertNull(node);
   }
 
   @Test
   void composeEmptyInputStream() {
     Compose compose = new Compose(LoadSettings.builder().build());
-    Node node = compose.composeInputStream(new ByteArrayInputStream("".getBytes()));
+    Node node = compose.compose(new ByteArrayInputStream("".getBytes()));
     assertNull(node);
   }
 
   @Test
   void composeAllFromEmptyReader() throws IOException {
     Compose compose = new Compose(LoadSettings.builder().build());
-    Iterable<Node> nodes = compose.composeAllFromReader(CharSource.wrap("").openStream());
+    Iterable<Node> nodes = compose.composeAll(CharSource.wrap("").openStream());
     assertFalse(nodes.iterator().hasNext());
   }
 
   @Test
   void composeAllFromEmptyInputStream() {
     Compose compose = new Compose(LoadSettings.builder().build());
-    Iterable<Node> nodes = compose.composeAllFromInputStream(new ByteArrayInputStream("".getBytes()));
+    Iterable<Node> nodes = compose.composeAll(new ByteArrayInputStream("".getBytes()));
     assertFalse(nodes.iterator().hasNext());
   }
 }

--- a/src/jvmTest/java/org/snakeyaml/engine/v2/common/SpecVersionTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/v2/common/SpecVersionTest.java
@@ -31,7 +31,7 @@ class SpecVersionTest {
   @DisplayName("Version 1.2 is accepted")
   void version12() {
     LoadSettings settings = LoadSettings.builder().setLabel("spec 1.2").build();
-    ScalarNode node = (ScalarNode) new Compose(settings).composeString("%YAML 1.2\n---\nfoo");
+    ScalarNode node = (ScalarNode) new Compose(settings).compose("%YAML 1.2\n---\nfoo");
     assertEquals("foo", node.getValue());
   }
 
@@ -39,7 +39,7 @@ class SpecVersionTest {
   @DisplayName("Version 1.3 is accepted by default")
   void version13() {
     LoadSettings settings = LoadSettings.builder().setLabel("spec 1.3").build();
-    ScalarNode node = (ScalarNode) new Compose(settings).composeString("%YAML 1.3\n---\nfoo");
+    ScalarNode node = (ScalarNode) new Compose(settings).compose("%YAML 1.3\n---\nfoo");
     assertEquals("foo", node.getValue());
   }
 
@@ -55,7 +55,7 @@ class SpecVersionTest {
           }
         }).build();
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-        () -> new Compose(settings).composeString("%YAML 1.3\n---\nfoo"));
+        () -> new Compose(settings).compose("%YAML 1.3\n---\nfoo"));
     assertEquals("Too high.", exception.getMessage());
   }
 
@@ -64,7 +64,7 @@ class SpecVersionTest {
   void version20() {
     LoadSettings settings = LoadSettings.builder().setLabel("spec 2.0").build();
     YamlVersionException exception = assertThrows(YamlVersionException.class,
-        () -> new Compose(settings).composeString("%YAML 2.0\n---\nfoo"));
+        () -> new Compose(settings).compose("%YAML 2.0\n---\nfoo"));
     assertEquals("Version{major=2, minor=0}", exception.getMessage());
   }
 }

--- a/src/jvmTest/java/org/snakeyaml/engine/v2/composer/ComposerTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/v2/composer/ComposerTest.java
@@ -30,7 +30,7 @@ class ComposerTest {
   @DisplayName("Fail to Compose one document when more documents are provided.")
   void composeOne() {
     ComposerException exception = assertThrows(ComposerException.class,
-        () -> new Compose(LoadSettings.builder().build()).composeString("a\n---\nb\n"));
+        () -> new Compose(LoadSettings.builder().build()).compose("a\n---\nb\n"));
     assertTrue(exception.getMessage().contains("expected a single document in the stream"));
     assertTrue(exception.getMessage().contains("but found another document"));
   }
@@ -38,7 +38,7 @@ class ComposerTest {
   @Test
   void failToComposeUnknownAlias() {
     ComposerException exception = assertThrows(ComposerException.class,
-        () -> new Compose(LoadSettings.builder().build()).composeString("[a, *id b]"));
+        () -> new Compose(LoadSettings.builder().build()).compose("[a, *id b]"));
     assertTrue(exception.getMessage().contains("found undefined alias id"), exception.getMessage());
   }
 
@@ -46,7 +46,7 @@ class ComposerTest {
   void composeAnchor() {
     String data = "--- &113\n{name: Bill, age: 18}";
     Compose compose = new Compose(LoadSettings.builder().build());
-    Node optionalNode = compose.composeString(data);
+    Node optionalNode = compose.compose(data);
     assertNotNull(optionalNode);
     assertEquals("113", optionalNode.getAnchor().getValue());
   }

--- a/src/jvmTest/java/org/snakeyaml/engine/v2/constructor/StandardConstructorTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/v2/constructor/StandardConstructorTest.java
@@ -29,7 +29,7 @@ class StandardConstructorTest {
   @Test
   void constructMergeExample() {
     Compose compose = new Compose(LoadSettings.builder().build());
-    Node node = compose.composeString(TestUtils.getResource("/load/list1.yaml"));
+    Node node = compose.compose(TestUtils.getResource("/load/list1.yaml"));
     assertNotNull(node);
     StandardConstructor constructor = new StandardConstructor(LoadSettings.builder().build());
     Object object = constructor.construct(node);

--- a/src/nativeMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
+++ b/src/nativeMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
@@ -2,33 +2,22 @@ package it.krzeminski.snakeyaml.engine.kmp.api.lowlevel
 
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
+import okio.Source
 
-/**
- * Helper to compose input stream to Node
- * @param settings - configuration
- */
 actual class Compose(settings: LoadSettings) {
+    private val common = ComposeCommon(settings)
 
-    private val composeString = ComposeString(settings)
+    actual fun compose(source: Source): Node? = common.compose(source)
 
-    /**
-     * Parse a YAML stream and produce [Node]
-     *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s).
-     * @return parsed [Node] if available
-     */
-    actual fun composeString(yaml: String): Node? = composeString.composeString(yaml)
+    actual fun compose(string: String): Node? = common.compose(string)
 
-    /**
-     * Parse all YAML documents in a stream and produce corresponding representation trees.
-     *
-     * See [Processing Overview](http://www.yaml.org/spec/1.2/spec.html.id2762107).
-     *
-     * @param yaml - YAML document(s).
-     * @return parsed root Nodes for all the specified YAML documents
-     */
-    actual fun composeAllFromString(yaml: String): Iterable<Node> =
-        composeString.composeAllFromString(yaml)
+    actual fun composeAll(source: Source): Iterable<Node> = common.composeAll(source)
+
+    actual fun composeAll(string: String): Iterable<Node> = common.composeAll(string)
+
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
+    actual fun composeString(yaml: String): Node? = compose(yaml)
+
+    @Deprecated("renamed", ReplaceWith("compose(yaml)"))
+    actual fun composeAllFromString(yaml: String): Iterable<Node> = composeAll(yaml)
 }

--- a/src/nativeMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
+++ b/src/nativeMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/lowlevel/Compose.kt
@@ -4,7 +4,9 @@ import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
 import okio.Source
 
-actual class Compose(settings: LoadSettings) {
+actual class Compose actual constructor(
+    settings: LoadSettings,
+) {
     private val common = ComposeCommon(settings)
 
     actual fun compose(source: Source): Node? = common.compose(source)


### PR DESCRIPTION
- Create ComposeCommon, for shared commonMain composing code
- Rename functions, so they're overloaded based on the arg type
- Deprecate unnecessary ComposeString
- De-duplicate/tidy KDoc