### PR TITLE
refactor YamlOutputStreamWriter

### DIFF
--- a/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/YamlOutputStreamWriter.kt
+++ b/src/jvmMain/java/it/krzeminski/snakeyaml/engine/kmp/api/YamlOutputStreamWriter.kt
@@ -24,16 +24,15 @@ import java.nio.charset.Charset
  * @param out the output
  * @param cs encoding to use to translate String to bytes
  */
-abstract class YamlOutputStreamWriter(
+open class YamlOutputStreamWriter(
     out: OutputStream,
     cs: Charset,
 ) : OutputStreamWriter(out, cs), StreamDataWriter {
-    /**
-     * to be implemented
-     *
-     * @param e - the reason
-     */
-    abstract fun processIOException(e: IOException?)
+
+    /** Handle [IOException]s thrown while writing. */
+    open fun processIOException(e: IOException) {
+        throw e
+    }
 
     override fun flush() {
         try {

--- a/src/jvmTest/java/org/snakeyaml/engine/v2/api/DumpTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/v2/api/DumpTest.java
@@ -120,12 +120,7 @@ class DumpTest {
     assertFalse(file.exists());
     file.getParentFile().mkdirs();
     file.createNewFile();
-    StreamDataWriter writer = new YamlOutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8) {
-      @Override
-      public void processIOException(IOException e) {
-        throw new RuntimeException(e);
-      }
-    };
+    StreamDataWriter writer = new YamlOutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
     dump.dump(ImmutableMap.of("x", 1, "y", 2, "z", 3), writer);
     assertTrue(file.exists());
     file.delete();// on Windows the file is not deleted


### PR DESCRIPTION
- Update KDoc
- IOException shouldn't be nullable
- provide default implementation for `processIOException()`
- change class from `abstract` to `open`, so it's easier to use