### PR TITLE
remove editorconfig from Project.xml codestyle

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -9,9 +9,6 @@
       <option name="ALIGN_IN_COLUMNS_CASE_BRANCH" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
-    <editorconfig>
-      <option name="ENABLED" value="true" />
-    </editorconfig>
     <codeStyleSettings language="JAVA">
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />


### PR DESCRIPTION
IntelliJ keeps removing the `<editorconfig>` section - I think it's not necessary any more.

Follow-up to #165 