### PR TITLE
Refactor Mark

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/exceptions/Mark.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/exceptions/Mark.kt
@@ -13,9 +13,9 @@
  */
 package it.krzeminski.snakeyaml.engine.kmp.exceptions
 
-import it.krzeminski.snakeyaml.engine.kmp.internal.utils.appendCodePoint
-import it.krzeminski.snakeyaml.engine.kmp.internal.utils.toCodePoints
 import it.krzeminski.snakeyaml.engine.kmp.common.CharConstants
+import it.krzeminski.snakeyaml.engine.kmp.internal.utils.joinCodepointsToString
+import it.krzeminski.snakeyaml.engine.kmp.internal.utils.toCodePoints
 import kotlin.jvm.JvmOverloads
 
 /**
@@ -26,20 +26,28 @@ import kotlin.jvm.JvmOverloads
  * @param index the index from the beginning of the stream
  * @param line line of the mark from beginning of the stream
  * @param column column of the mark from beginning of the line
- * @param buffer the data
- * @param pointer the position of the mark from the beginning of the data
+ * @param codepoints the data
+ * @param pointer the index of the character in [codepoints] that will be marked
  */
-class Mark(
+class Mark @JvmOverloads constructor(
     val name: String,
     val index: Int,
     val line: Int,
     val column: Int,
-    val buffer: IntArray,
-    val pointer: Int,
+    val codepoints: List<Int>,
+    val pointer: Int = 0,
 ) {
 
+    @Deprecated("Converted to immutable List<Int>, replace with `codepoints`")
+    val buffer: IntArray = codepoints.toIntArray()
+
     /**
-     * This constructor is only for test
+     * Deprecated: please convert [str] to codepoints.
+     *
+     * ```java
+     * // java
+     * List<Integer> codepoints = str.codePoints().boxed().collect(Collectors.toList());
+     * ```
      *
      * @param name the name to be used as identifier
      * @param index the index from the beginning of the stream
@@ -48,80 +56,107 @@ class Mark(
      * @param str the data
      * @param pointer the position of the mark from the beginning of the data
      */
+    @JvmOverloads
+    @Deprecated("No longer used - please convert CharSequence to codepoints")
     internal constructor(
         name: String,
         index: Int,
         line: Int,
         column: Int,
         str: CharSequence,
-        pointer: Int,
+        pointer: Int = 0,
     ) : this(
         name = name,
         index = index,
         line = line,
         column = column,
-        buffer = str.toCodePoints(),
+        codepoints = str.toCodePoints(),
+        pointer = pointer,
+    )
+
+    @JvmOverloads
+    @Deprecated("No longer used - please use a List<Int> instead of IntArray")
+    internal constructor(
+        name: String,
+        index: Int,
+        line: Int,
+        column: Int,
+        buffer: IntArray,
+        pointer: Int = 0,
+    ) : this(
+        name = name,
+        index = index,
+        line = line,
+        column = column,
+        codepoints = buffer.toList(),
         pointer = pointer,
     )
 
     private fun isLineBreak(c: Int): Boolean = CharConstants.NULL_OR_LINEBR.has(c)
 
     /**
-     * Create readable YAML with indent 4 and (by default) a [maxLength] of 75 characters.
+     * Create readable YAML snippet of [codepoints], with a caret `^` pointing at [pointer].
      *
-     * @param indent the indent
-     * @param maxLength cut data after this length
-     * @return readable piece of YAML where a problem detected
+     * Only a single line will be rendered. Content before or after a linebreak will not be shown.
+     *
+     * Lines longer than [maxLength] will be truncated, using [SNIPPET_OVERFLOW] to indicate truncation.
+     *
+     * @param indentSize The number of spaces to indent the snippet.
+     * @param maxLength Limit the result to this many characters.
+     * @return readable Piece of YAML that highlights a .
      */
     @JvmOverloads
     // TODO this function is only exposed because of testing - mark as `internal` once tests are Kotlin
     fun createSnippet(
-        indent: Int = 4,
+        indentSize: Int = 4,
         maxLength: Int = 75,
     ): String {
-        val half = maxLength / 2f - 1f
-        var start = pointer
-        var head = ""
-        while (start > 0 && !isLineBreak(buffer[start - 1])) {
-            start -= 1
-            if (pointer - start > half) {
-                head = " ... "
-                start += 5
-                break
-            }
+        val halfMaxLength = maxLength / 2
+
+        val lineBeforePointer = codepoints
+            .take(pointer)
+            .takeLastWhile { !isLineBreak(it) }
+            .joinCodepointsToString()
+
+        val lineAfterPointer = codepoints
+            .drop(pointer)
+            .takeWhile { !isLineBreak(it) }
+            .joinCodepointsToString()
+
+        val head = if (lineBeforePointer.length > halfMaxLength) {
+            SNIPPET_OVERFLOW + lineBeforePointer.takeLast(halfMaxLength).drop(SNIPPET_OVERFLOW.length)
+        } else {
+            lineBeforePointer
         }
-        var tail = ""
-        var end = pointer
-        while (end < buffer.size && !isLineBreak(buffer[end])) {
-            end += 1
-            if (end - pointer > half) {
-                tail = " ... "
-                end -= 5
-                break
-            }
+
+        val tail = if (lineAfterPointer.length > halfMaxLength) {
+            lineAfterPointer.take(halfMaxLength).dropLast(SNIPPET_OVERFLOW.length) + SNIPPET_OVERFLOW
+        } else {
+            lineAfterPointer
         }
-        val result = StringBuilder()
-        for (i in 0 until indent) {
-            result.append(" ")
+
+        val indent = " ".repeat(indentSize)
+        return buildString {
+            append(indent)
+            append(head)
+            append(tail)
+            appendLine()
+
+            append(indent)
+            append(" ".repeat(head.length))
+            append("^")
         }
-        result.append(head)
-        for (i in start until end) {
-            result.appendCodePoint(buffer[i])
-        }
-        result.append(tail)
-        result.append("\n")
-        for (i in 0 until indent + pointer - start + head.length) {
-            result.append(" ")
-        }
-        result.append("^")
-        return result.toString()
     }
 
     override fun toString(): String {
         val snippet = createSnippet()
         return """
-            | in $name, line ${line + 1}, column ${column + 1}:
+            | in ${name.trim()}, line ${line + 1}, column ${column + 1}:
             |$snippet
         """.trimMargin()
+    }
+
+    companion object {
+        private const val SNIPPET_OVERFLOW = " ... "
     }
 }

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/utils/AppendableExtensions.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/utils/AppendableExtensions.kt
@@ -28,10 +28,11 @@ package it.krzeminski.snakeyaml.engine.kmp.internal.utils
 /**
  * Appends the string representation of the [codePoint] argument to this Appendable and returns this instance.
  *
- * To append the codepoint, [Appendable.append(Char)][Appendable.append] is called [CodePoints.charCount] times.
+ * To append the codepoint, [Appendable.append(Char)][Appendable.append] is called
+ * [Character.charCount] times.
  *
  * The overall effect is exactly as if the argument were converted to a char array by the function
- * [CodePoints.toChars] and the characters in that array were then appended to this Appendable.
+ * [Character.toChars] and the characters in that array were then appended to this Appendable.
  */
 internal fun <T : Appendable> T.appendCodePoint(codePoint: Int): Appendable {
     if (Character.isBmpCodePoint(codePoint)) {
@@ -40,5 +41,15 @@ internal fun <T : Appendable> T.appendCodePoint(codePoint: Int): Appendable {
         append(Character.highSurrogateOf(codePoint))
         append(Character.lowSurrogateOf(codePoint))
     }
+    return this
+}
+
+internal fun Iterable<Int>.joinCodepointsToString(): String =
+    buildString {
+        appendCodePoints(this@joinCodepointsToString)
+    }
+
+private fun <T : Appendable> T.appendCodePoints(codePoints: Iterable<Int>): T {
+    codePoints.forEach { appendCodePoint(it) }
     return this
 }

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/utils/CharSequenceExtensions.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/utils/CharSequenceExtensions.kt
@@ -71,17 +71,17 @@ internal fun CharArray.codePointCount(
 }
 
 
-internal fun CharSequence.toCodePoints(): IntArray {
-    val codePoints = IntArray(codePointCount())
-    var i = 0
-    var c = 0
-    while (i < length) {
-        val cp = codePointAt(i)
-        codePoints[c] = cp
-        i += Character.charCount(cp)
-        c++
+internal fun CharSequence.toCodePoints(): List<Int> {
+    return buildList(length) {
+        var i = 0
+        var c = 0
+        while (i < length) {
+            val cp = codePointAt(i)
+            add(cp)
+            i += Character.charCount(cp)
+            c++
+        }
     }
-    return codePoints
 }
 
 

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/utils/Character.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/utils/Character.kt
@@ -39,7 +39,7 @@ internal object Character {
      *
      * The Unicode code points are divided into two categories:
      * Basic Multilingual Plane (BMP) code points and Supplementary code points.
-     * BMP code points are present in the range U+0000 to U+FFFF.
+     * BMP code points are present in the range `U+0000` to `U+FFFF`.
      *
      * Whereas, supplementary characters are rare characters that are not represented using the original 16-bit Unicode.
      * For example, these type of characters are used in Chinese or Japanese scripts and hence, are required by the

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
@@ -98,7 +98,7 @@ class StreamReader(
             index = index,
             line = line,
             column = column,
-            buffer = codePointsWindow,
+            codepoints = codePointsWindow.toList(),
             pointer = pointer,
         )
     }

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/inherited/CanonicalScanner.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/inherited/CanonicalScanner.java
@@ -21,7 +21,9 @@ import it.krzeminski.snakeyaml.engine.kmp.tokens.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class CanonicalScanner implements Scanner {
 
@@ -80,7 +82,8 @@ public class CanonicalScanner implements Scanner {
     this.index = 0;
     this.tokens = new ArrayList<>();
     this.scanned = false;
-    this.mark = new Mark("test", 0, 0, 0, data, 0);
+    List<Integer> codepoints = data.codePoints().boxed().collect(Collectors.toList());
+    this.mark = new Mark("test", 0, 0, 0, codepoints, 0);
   }
 
   public boolean checkToken(Token.ID... choices) {

--- a/src/jvmTest/java/org/snakeyaml/engine/usecases/inherited/InheritedMarkTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/usecases/inherited/InheritedMarkTest.java
@@ -13,9 +13,12 @@
  */
 package org.snakeyaml.engine.usecases.inherited;
 
+import it.krzeminski.snakeyaml.engine.kmp.exceptions.Mark;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import it.krzeminski.snakeyaml.engine.kmp.exceptions.Mark;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,11 +45,11 @@ public class InheritedMarkTest extends InheritedImportTest {
         }
         index += 1;
       }
-      Mark mark = new Mark("testMarks", index, line, column, input, index);
+      List<Integer> inputCodepoints = input.codePoints().boxed().collect(Collectors.toList());
+      Mark mark = new Mark("testMarks", index, line, column, inputCodepoints, index);
       String snippet = mark.createSnippet(2, 79);
-      assertTrue(snippet.indexOf("\n") > -1, "Must only have one '\n'.");
-      assertEquals(snippet.indexOf("\n"), snippet.lastIndexOf("\n"),
-          "Must only have only one '\n'.");
+      assertTrue(snippet.contains("\n"), "Must contain at least one '\n'.");
+      assertEquals(snippet.indexOf("\n"), snippet.lastIndexOf("\n"), "Must only have only one '\n'.");
       String[] lines = snippet.split("\n");
       String data = lines[0];
       String pointer = lines[1];

--- a/src/jvmTest/java/org/snakeyaml/engine/v2/events/EventTest.java
+++ b/src/jvmTest/java/org/snakeyaml/engine/v2/events/EventTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import it.krzeminski.snakeyaml.engine.kmp.common.Anchor;
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.Mark;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("fast")
@@ -34,7 +36,7 @@ class EventTest {
 
   @Test
   void bothMarks() {
-    Mark fake = new Mark("a", 0, 0, 0, new int[0], 0);
+    Mark fake = new Mark("a", 0, 0, 0, List.of(), 0);
     NullPointerException exception = assertThrows(NullPointerException.class,
         () -> new StreamStartEvent(null, fake));
     assertEquals("Both marks must be either present or absent.", exception.getMessage());


### PR DESCRIPTION
- Change codepoint buffer from mutable `IntArray` to read-only `List<Int>`
- Deprecate alternate constructors. They were only used in tests, and the 'real' constructor wasn't tested.
- update kdoc
- trim Mark.name in `toString()` (the yaml-test-suite tests end with newlines, which lead to weird output messages)
- refactor `createSnippet()` to be more Kotlin-ey
- add more Character & Codepoint utils