### PR TITLE
Add performance comparison to snakeyaml-engine

### DIFF
--- a/snake-kmp-benchmarks/build.gradle.kts
+++ b/snake-kmp-benchmarks/build.gradle.kts
@@ -56,6 +56,12 @@ kotlin {
             }
         }
 
+        jvmMain {
+            dependencies {
+                implementation("org.snakeyaml:snakeyaml-engine:2.7")
+            }
+        }
+
         jsMain {
             dependencies {
                 implementation("net.thauvin.erik.urlencoder:urlencoder-lib:1.5.0") {

--- a/snake-kmp-benchmarks/src/jvmMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/benchmark/SnakeyamlEngineJvmLoadingTimeBenchmark.kt
+++ b/snake-kmp-benchmarks/src/jvmMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/benchmark/SnakeyamlEngineJvmLoadingTimeBenchmark.kt
@@ -35,7 +35,7 @@ class SnakeyamlEngineJvmLoadingTimeBenchmark {
                 handle.source().buffer().use { source ->
                     val reader = StreamReader(
                         loadSettings,
-                        YamlUnicodeReader(source.inputStream()).readText(),
+                        YamlUnicodeReader(source.inputStream()),
                     )
                     val composer = Composer(
                         loadSettings,

--- a/snake-kmp-benchmarks/src/jvmMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/benchmark/SnakeyamlEngineJvmLoadingTimeBenchmark.kt
+++ b/snake-kmp-benchmarks/src/jvmMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/benchmark/SnakeyamlEngineJvmLoadingTimeBenchmark.kt
@@ -1,0 +1,52 @@
+package it.krzeminski.snakeyaml.engine.kmp.benchmark
+
+import kotlinx.benchmark.*
+import okio.Path.Companion.toPath
+import okio.buffer
+import okio.use
+import org.snakeyaml.engine.v2.api.LoadSettings
+import org.snakeyaml.engine.v2.api.YamlUnicodeReader
+import org.snakeyaml.engine.v2.composer.Composer
+import org.snakeyaml.engine.v2.constructor.BaseConstructor
+import org.snakeyaml.engine.v2.constructor.StandardConstructor
+import org.snakeyaml.engine.v2.parser.ParserImpl
+import org.snakeyaml.engine.v2.scanner.StreamReader
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+class SnakeyamlEngineJvmLoadingTimeBenchmark {
+    @Param("")
+    var openAiYamlPath: String = ""
+
+    private val loadSettings = LoadSettings.builder().build()
+
+    private lateinit var constructor: BaseConstructor
+
+    @Setup
+    fun setUp() {
+        constructor = StandardConstructor(loadSettings)
+    }
+
+    @Benchmark
+    fun loadsOpenAiSchema(): Map<*, *> {
+        return with(fileSystem()) {
+            openReadOnly(openAiYamlPath.toPath(normalize = true)).use { handle ->
+                handle.source().buffer().use { source ->
+                    val reader = StreamReader(
+                        loadSettings,
+                        YamlUnicodeReader(source.inputStream()).readText(),
+                    )
+                    val composer = Composer(
+                        loadSettings,
+                        ParserImpl(
+                            loadSettings,
+                            reader,
+                        )
+                    )
+                    constructor.constructSingleDocument(composer.getSingleNode()) as Map<*, *>
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This way we should have a reference point to the implementation where SnakeYAML Engine KMP was forked from.