### PR TITLE
Configure separate repo for benchmark testing

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -88,7 +88,7 @@ jobs:
         summary-always: true
         alert-threshold: '150%'
         fail-threshold: '200%'
-        gh-repository: ${{ github.event_name == 'pull_request' && 'github.com/krzema12/snakeyaml-engine-kmp-benchmarks' || 'github.com/krzema12/snakeyaml-engine-kmp-benchmarks-testing' }}
+        gh-repository: ${{ github.event_name != 'pull_request' && 'github.com/krzema12/snakeyaml-engine-kmp-benchmarks' || 'github.com/krzema12/snakeyaml-engine-kmp-benchmarks-testing' }}
         github-token: ${{ secrets.PUBLISH_BENCHMARK_RESULTS }}
         # Push and deploy GitHub pages branch automatically only if run in main repo
         auto-push: ${{ github.repository == 'krzema12/snakeyaml-engine-kmp'}}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -88,7 +88,7 @@ jobs:
         summary-always: true
         alert-threshold: '150%'
         fail-threshold: '200%'
-        gh-repository: github.com/krzema12/snakeyaml-engine-kmp-benchmarks
+        gh-repository: ${{ github.event_name == 'pull_request' && 'github.com/krzema12/snakeyaml-engine-kmp-benchmarks' || 'github.com/krzema12/snakeyaml-engine-kmp-benchmarks-testing' }}
         github-token: ${{ secrets.PUBLISH_BENCHMARK_RESULTS }}
-        # Push and deploy GitHub pages branch automatically only if run in main repo and not in PR
-        auto-push: ${{ github.repository == 'krzema12/snakeyaml-engine-kmp' && github.event_name != 'pull_request' }}
+        # Push and deploy GitHub pages branch automatically only if run in main repo
+        auto-push: ${{ github.repository == 'krzema12/snakeyaml-engine-kmp'}}


### PR DESCRIPTION
The goal is to be able to test changes in the performance report generation within PR. The report will be pushed to a separate repo, see https://krzema12.github.io/snakeyaml-engine-kmp-benchmarks-testing/dev/bench/