### PR TITLE
Check consistency and compilability of all GitHub workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,3 +109,41 @@ jobs:
     - id: 'step-4'
       name: 'Build'
       run: './gradlew build --stacktrace'
+  build_kotlin_scripts:
+    name: 'Build Kotlin scripts'
+    runs-on: 'ubuntu-latest'
+    needs:
+    - 'check_yaml_consistency'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      run: |-
+        find -name *.main.kts -print0 | while read -d $'\0' file
+        do
+            echo "Compiling $file..."
+            kotlinc -Werror -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "$file"
+        done
+  workflows_consistency_check:
+    name: 'Run consistency check on all GitHub workflows'
+    runs-on: 'ubuntu-latest'
+    needs:
+    - 'check_yaml_consistency'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      run: 'cd .github/workflows'
+    - id: 'step-2'
+      name: 'Regenerate all workflow YAMLs'
+      run: |-
+        find -name "*.main.kts" -print0 | while read -d $'\0' file
+        do
+            if [ -x "$file" ]; then
+                echo "Regenerating $file..."
+                ($file)
+            fi
+        done
+    - id: 'step-3'
+      name: 'Check if some file is different after regeneration'
+      run: 'git diff --exit-code .'


### PR DESCRIPTION
Now that we have a workflow that runs only on demand, and not in every PR or on the `main` branch, it's beneficial to have these extra checks.

BTW, I noticed this piece is useful in almost every project, and I'm planning to release some kind of util (a GitHub action?) that would encapsulate this logic. It's tracked in https://github.com/typesafegithub/github-workflows-kt/issues/213

Examples of using this approach in other repos:
* https://github.com/typesafegithub/github-workflows-kt/blob/0e91c566849a5883b39021a5ecbc18d25b006c1b/.github/workflows/build.main.kts#L95
* https://github.com/typesafegithub/github-actions-typing-catalog/blob/667df7ec3fc639d19e278fc5956a9f753b26bb90/.github/workflows/test.main.kts#L14