### PR TITLE
Execute drop staging repo job in case of failure

### DIFF
--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -120,7 +120,7 @@ workflow(
     job(
         id = "drop-staging-repo",
         runsOn = RunnerType.UbuntuLatest,
-        condition = expr { publishJob.result.neq(AbstractResult.Status.Success) },
+        condition = expr { "!${cancelled()} && ${publishJob.result.neq(AbstractResult.Status.Success)}" },
         needs = listOf(stagingRepoJob, publishJob),
     ) {
         uses(

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,7 @@ jobs:
     - 'create-staging-repo'
     - 'publish-artifacts'
     - 'check_yaml_consistency'
-    if: '${{ needs.publish-artifacts.result != ''success'' }}'
+    if: '${{ !cancelled() && needs.publish-artifacts.result != ''success'' }}'
     steps:
     - id: 'step-0'
       uses: 'nexus-actions/drop-nexus-staging-repo@v1'


### PR DESCRIPTION
In the test run the job to drop staging repo was not executed after publication failed. This should solve the problem.

Part of #94