### PR TITLE
[Port from snakeyaml-engine] Scanner#checkToken(Token.ID) avoids varargs

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/Scanner.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/Scanner.kt
@@ -35,6 +35,18 @@ interface Scanner : Iterator<Token> {
     fun checkToken(vararg choices: Token.ID): Boolean
 
     /**
+     * Check if the next token is the given type.
+     *
+     * @param choice token ID to match with
+     * @return `true` if the next token is the given type. Returns `false`
+     * if no more tokens are available.
+     * @throws ScannerException Thrown in case of malformed input.
+     */
+    fun checkToken(choice: Token.ID): Boolean {
+        return checkToken(choices=arrayOf(choice))
+    }
+
+    /**
      * Return the next token, but do not delete it from the stream.
      *
      * @return The token that will be returned on the next call to [next]

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ScannerImpl.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ScannerImpl.kt
@@ -114,6 +114,19 @@ class ScannerImpl(
     }
 
     /**
+     * Check whether the next token is the given type.
+     */
+    override fun checkToken(choice: Token.ID): Boolean {
+        while (needMoreTokens()) {
+            fetchMoreTokens()
+        }
+        if (!this.tokens.isEmpty()) {
+            return this.tokens[0].tokenId == choice
+        }
+        return false
+    }
+
+    /**
      * Check whether the next token is present.
      *
      * If no [choices] are provided, then any token is considered valid.


### PR DESCRIPTION
Closes https://github.com/krzema12/snakeyaml-engine-kmp/issues/290

Ports https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/b26779e3887d8d6b89e7e3c375bc497e3c8c5be9