### PR TITLE
[Port from snakeyaml-engine] Allow HighSurrogate to be the last char in the data window

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadSettingsBuilder.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadSettingsBuilder.kt
@@ -120,10 +120,10 @@ class LoadSettingsBuilder internal constructor() {
 
     /**
      * YAML 1.2 does require unique keys. To support the backwards compatibility it is possible to
-     * select what should happend when non-unique keys are detected.
+     * select what should happen when non-unique keys are detected.
      *
-     * @param allowDuplicateKeys - if `true` then the non-unique keys in a mapping are allowed (last key
-     * wins). `false` by default.
+     * @param allowDuplicateKeys - if `true`, then the non-unique keys in a mapping are allowed (last
+     * key wins). `false` by default.
      * @return the builder with the provided value
      */
     fun setAllowDuplicateKeys(allowDuplicateKeys: Boolean): LoadSettingsBuilder {

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
@@ -192,14 +192,6 @@ class StreamReader(
             if (read > 0) {
                 var cpIndex = dataLength - pointer
                 codePointsWindow = codePointsWindow.copyOfRangeSafe(pointer, dataLength + read)
-                // Okio seems to make this check redundant, which is a good because I have no idea how to convert it sensibly!
-                //if (buffer.last().isHighSurrogate()) {
-                //    if (stream.read(buffer, read, 1) == -1) {
-                //        eof = true
-                //    } else {
-                //        read++
-                //    }
-                //}
                 var nonPrintable: Int? = null
                 var i = 0
                 while (i < read) {

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
@@ -29,6 +29,7 @@ import kotlin.jvm.JvmStatic
  * Reads the provided [stream] of code points, and implements look-ahead operations.
  *
  * Checks if code points are in the allowed range.
+ * If [stream] contains invalid UTF-8-encoded bytes, they will be replaced with `?`.
  *
  * @param loadSettings configuration options
  * @param stream the input

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ReaderStringTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ReaderStringTest.kt
@@ -36,7 +36,7 @@ class ReaderStringTest : FunSpec({
             } else if (i.toChar().isLowSurrogate()) {
                 lowSurrogatesCounter++
             } else {
-                val str = CharArray(1) { i.toChar() }.concatToString()
+                val str = charArrayOf(i.toChar()).concatToString()
                 val regularExpressionResult = StreamReader.isPrintable(str)
 
                 var charsArrayResult = true
@@ -65,7 +65,7 @@ class ReaderStringTest : FunSpec({
 
     test("high surrogates alone") {
         for (i in 0xD800..0xDBFF) {
-            val str = CharArray(1) { i.toChar() }.concatToString()
+            val str = charArrayOf(i.toChar()).concatToString()
             val reader = StreamReader(LoadSettings.builder().build(), str)
             reader.peek() shouldBe '?'.code
         }
@@ -73,7 +73,7 @@ class ReaderStringTest : FunSpec({
 
     test("low surrogates alone") {
         for (i in 0xDC00..0xDFFF) {
-            val str = CharArray(1) { i.toChar() }.concatToString()
+            val str = charArrayOf(i.toChar()).concatToString()
             val reader = StreamReader(LoadSettings.builder().build(), str)
             reader.peek() shouldBe '?'.code
         }

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ReaderStringTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ReaderStringTest.kt
@@ -41,7 +41,7 @@ class ReaderStringTest : FunSpec({
                     StreamReader(LoadSettings.builder().build(), str).peek()
                 } catch (e: Exception) {
                     (
-                        e.message?.startsWith("unacceptable character") ?: false
+                        (e.message?.startsWith("unacceptable character") ?: false)
                             || e.message == "special characters are not allowed"
                     ) shouldBe true
                     charsArrayResult = false
@@ -59,13 +59,13 @@ class ReaderStringTest : FunSpec({
 
     test("high surrogate alone") {
         val reader = StreamReader(LoadSettings.builder().build(), "test\uD800")
-        shouldThrow<ReaderException> {
+        try {
             while (reader.peek() != 0) {
                 reader.forward()
             }
-        }.also {
-            it.toString() shouldContain "(0xD800) The last char is HighSurrogate (no LowSurrogate detected)"
-            it.position shouldBe 5
+        } catch(e: ReaderException) {
+            e.toString() shouldContain "(0xD800) The last char is HighSurrogate (no LowSurrogate detected)"
+            e.position shouldBe 5
         }
     }
 
@@ -75,26 +75,26 @@ class ReaderStringTest : FunSpec({
             reader.forward(1)
         }
         val reader2 = StreamReader(LoadSettings.builder().build(), "test")
-        reader2.peek() shouldBe 't'
+        reader2.peek() shouldBe 't'.code
         reader2.forward()
-        reader2.peek() shouldBe 'e'
+        reader2.peek() shouldBe 'e'.code
         reader2.forward()
-        reader2.peek() shouldBe 's'
+        reader2.peek() shouldBe 's'.code
         reader2.forward()
-        reader2.peek() shouldBe 't'
+        reader2.peek() shouldBe 't'.code
         reader2.forward()
         reader2.peek() shouldBe 0
     }
 
     test("peek int") {
         val reader = StreamReader(LoadSettings.builder().build(), "test")
-        reader.peek(0) shouldBe 't'
-        reader.peek(1) shouldBe 'e'
-        reader.peek(2) shouldBe 's'
-        reader.peek(3) shouldBe 't'
+        reader.peek(0) shouldBe 't'.code
+        reader.peek(1) shouldBe 'e'.code
+        reader.peek(2) shouldBe 's'.code
+        reader.peek(3) shouldBe 't'.code
         reader.forward(1)
-        reader.peek(0) shouldBe 'e'
-        reader.peek(1) shouldBe 's'
-        reader.peek(2) shouldBe 't'
+        reader.peek(0) shouldBe 'e'.code
+        reader.peek(1) shouldBe 's'.code
+        reader.peek(2) shouldBe 't'.code
     }
 })

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ReaderStringTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ReaderStringTest.kt
@@ -63,15 +63,19 @@ class ReaderStringTest : FunSpec({
         }
     }
 
-    test("high surrogate alone") {
-        val reader = StreamReader(LoadSettings.builder().build(), "test\uD800")
-        try {
-            while (reader.peek() != 0) {
-                reader.forward()
-            }
-        } catch(e: ReaderException) {
-            e.toString() shouldContain "(0xD800) The last char is HighSurrogate (no LowSurrogate detected)"
-            e.position shouldBe 5
+    test("high surrogates alone") {
+        for (i in 0xD800..0xDBFF) {
+            val str = CharArray(1) { i.toChar() }.concatToString()
+            val reader = StreamReader(LoadSettings.builder().build(), str)
+            reader.peek() shouldBe '?'.code
+        }
+    }
+
+    test("low surrogates alone") {
+        for (i in 0xDC00..0xDFFF) {
+            val str = CharArray(1) { i.toChar() }.concatToString()
+            val reader = StreamReader(LoadSettings.builder().build(), str)
+            reader.peek() shouldBe '?'.code
         }
     }
 

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ReaderStringTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ReaderStringTest.kt
@@ -28,10 +28,13 @@ class ReaderStringTest : FunSpec({
     }
 
     test("check all") {
-        var counterSurrogates = 0
+        var highSurrogatesCounter = 0
+        var lowSurrogatesCounter = 0
         for (i in 0..<256 * 256) {
             if (i.toChar().isHighSurrogate()) {
-                counterSurrogates++
+                highSurrogatesCounter++
+            } else if (i.toChar().isLowSurrogate()) {
+                lowSurrogatesCounter++
             } else {
                 val str = CharArray(1) { i.toChar() }.concatToString()
                 val regularExpressionResult = StreamReader.isPrintable(str)
@@ -52,8 +55,11 @@ class ReaderStringTest : FunSpec({
             }
         }
         // https://en.wikipedia.org/wiki/Universal_Character_Set_characters
-        withClue("There are 1024 high surrogates (D800–DBFF)") {
-            counterSurrogates shouldBe 1024
+        withClue("There are 1024 low surrogates (D800–DBFF)") {
+            highSurrogatesCounter shouldBe 1024
+        }
+        withClue("There are 1024 high surrogates (DC00–DFFF)") {
+            lowSurrogatesCounter shouldBe 1024
         }
     }
 

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ReaderStringTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ReaderStringTest.kt
@@ -1,0 +1,100 @@
+package it.krzeminski.snakeyaml.engine.kmp.scanner
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
+import it.krzeminski.snakeyaml.engine.kmp.exceptions.ReaderException
+
+class ReaderStringTest : FunSpec({
+    test("check printable") {
+        val reader = StreamReader(LoadSettings.builder().build(), "test")
+        reader.peek(4) shouldBe 0
+        StreamReader.isPrintable("test") shouldBe true
+    }
+
+    test("check non-printable") {
+        StreamReader.isPrintable("test\u0005 fail") shouldBe false
+        shouldThrow<ReaderException> {
+            val reader = StreamReader(LoadSettings.builder().build(), "test\u0005 fail")
+            while (reader.peek() != 0) {
+                reader.forward()
+            }
+        }.also {
+            it.toString() shouldBe "unacceptable code point '\u0005' (0x5) special characters are not allowed\nin \"reader\", position 4"
+        }
+    }
+
+    test("check all") {
+        var counterSurrogates = 0
+        for (i in 0..<256 * 256) {
+            if (i.toChar().isHighSurrogate()) {
+                counterSurrogates++
+            } else {
+                val str = CharArray(1) { i.toChar() }.concatToString()
+                val regularExpressionResult = StreamReader.isPrintable(str)
+
+                var charsArrayResult = true
+                try {
+                    StreamReader(LoadSettings.builder().build(), str).peek()
+                } catch (e: Exception) {
+                    (
+                        e.message?.startsWith("unacceptable character") ?: false
+                            || e.message == "special characters are not allowed"
+                    ) shouldBe true
+                    charsArrayResult = false
+                }
+                withClue("Failed for #$i") {
+                    regularExpressionResult shouldBe charsArrayResult
+                }
+            }
+        }
+        // https://en.wikipedia.org/wiki/Universal_Character_Set_characters
+        withClue("There are 1024 high surrogates (D800–DBFF)") {
+            counterSurrogates shouldBe 1024
+        }
+    }
+
+    test("high surrogate alone") {
+        val reader = StreamReader(LoadSettings.builder().build(), "test\uD800")
+        shouldThrow<ReaderException> {
+            while (reader.peek() != 0) {
+                reader.forward()
+            }
+        }.also {
+            it.toString() shouldContain "(0xD800) The last char is HighSurrogate (no LowSurrogate detected)"
+            it.position shouldBe 5
+        }
+    }
+
+    test("forward") {
+        val reader = StreamReader(LoadSettings.builder().build(), "test")
+        while (reader.peek() != 0) {
+            reader.forward(1)
+        }
+        val reader2 = StreamReader(LoadSettings.builder().build(), "test")
+        reader2.peek() shouldBe 't'
+        reader2.forward()
+        reader2.peek() shouldBe 'e'
+        reader2.forward()
+        reader2.peek() shouldBe 's'
+        reader2.forward()
+        reader2.peek() shouldBe 't'
+        reader2.forward()
+        reader2.peek() shouldBe 0
+    }
+
+    test("peek int") {
+        val reader = StreamReader(LoadSettings.builder().build(), "test")
+        reader.peek(0) shouldBe 't'
+        reader.peek(1) shouldBe 'e'
+        reader.peek(2) shouldBe 's'
+        reader.peek(3) shouldBe 't'
+        reader.forward(1)
+        reader.peek(0) shouldBe 'e'
+        reader.peek(1) shouldBe 's'
+        reader.peek(2) shouldBe 't'
+    }
+})


### PR DESCRIPTION
Ports https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/c36e42f972c53d851a91e2a2c6323a4c066da662
This PR actually doesn't modify the behavior because we use Okio which handles reading UTF-8 for us. We just need to port the tests and make some adjustments in the docstrings.

Closes https://github.com/krzema12/snakeyaml-engine-kmp/issues/292