### PR TITLE
Handle non-existing common test resources gracefully

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,6 +55,17 @@ dependencyResolutionManagement {
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.9.0")
+    id("com.gradle.develocity") version "3.19"
+}
+
+develocity {
+    buildScan {
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
+        publishing.onlyIf {
+            System.getenv("GITHUB_ACTIONS") == "true" && it.buildResult.failures.isNotEmpty()
+        }
+    }
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
@@ -5,19 +5,28 @@ import okio.ByteString
 
 /**
  * Retrieves a string content from common resources using a given path.
- * TODO: Add proper error handling if the resource doesn't exist.
  *
  * @param path The slash-delimited path to the resource.
  * @return The content of the resource as a UTF-8 encoded string with normalized line breaks.
+ * @throws IllegalArgumentException if the resource doesn't exist.
  */
 fun stringFromResources(path: String): String {
     val segments = path.split("/")
     return (segments
         .dropLast(1)
-        .fold(CommonTestResources.resourcesMap) { map, segment ->
+        .fold(Pair(CommonTestResources.resourcesMap, "/resources/")) { (map, pathSoFar), directory ->
+            require(directory in map) {
+                "Directory '$directory' doesn't exist in directory '$pathSoFar'!"
+            }
             @Suppress("UNCHECKED_CAST")
-            map[segment] as Map<String, Any>
-        }[segments.last()] as ByteString).utf8()
+            Pair(map[directory] as Map<String, Any>, "$pathSoFar$directory/")
+        }).let { (map, pathSoFar) ->
+            val file = segments.last()
+            require(file in map) {
+                "File '$file' doesn't exist in directory '$pathSoFar'!"
+            }
+            map[file] as ByteString
+        }.utf8()
         // In this particular library, we produce uniform line breaks (\n)
         // on all OSes, hence it's desired to normalize them even if in
         // the resource file, we have a different kind of line breaks.

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
@@ -1,0 +1,31 @@
+package it.krzeminski.snakeyaml.engine.kmp
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class CommonTestResourcesAccessTest : FunSpec({
+    test("stringFromResources - resource exists") {
+        stringFromResources("test/resource/foo.txt") shouldBe """
+            Hello from multiplatform resources!
+            Foo bar baz
+
+        """.trimIndent()
+    }
+
+    test("stringFromResources - file doesn't exist") {
+        shouldThrow<IllegalArgumentException> {
+            stringFromResources("test/resource/does-not-exist.txt")
+        }.also {
+            it.message shouldBe "File 'does-not-exist.txt' doesn't exist in directory '/resources/test/resource/'!"
+        }
+    }
+
+    test("stringFromResources - directory doesn't exist") {
+        shouldThrow<IllegalArgumentException> {
+            stringFromResources("this/resource/for/sure/does/not/exist.txt")
+        }.also {
+            it.message shouldBe "Directory 'this' doesn't exist in directory '/resources/'!"
+        }
+    }
+})

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
@@ -7,7 +7,7 @@ import io.kotest.matchers.shouldBe
 class CommonTestResourcesAccessTest : FunSpec({
     test("stringFromResources - resource exists") {
         stringFromResources("test/resource/foo.txt") shouldBe """
-            Hello from multiplatform resources!
+            Hello from multiplatform! resources!
             Foo bar baz
 
         """.trimIndent()

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
@@ -7,7 +7,7 @@ import io.kotest.matchers.shouldBe
 class CommonTestResourcesAccessTest : FunSpec({
     test("stringFromResources - resource exists") {
         stringFromResources("test/resource/foo.txt") shouldBe """
-            Hello from multiplatform! resources!
+            Hello from multiplatform resources!
             Foo bar baz
 
         """.trimIndent()

--- a/src/commonTest/resources/test/resource/foo.txt
+++ b/src/commonTest/resources/test/resource/foo.txt
@@ -1,0 +1,2 @@
+Hello from multiplatform resources!
+Foo bar baz


### PR DESCRIPTION
Closes https://github.com/krzema12/snakeyaml-engine-kmp/issues/323

Replaces NPE with an IllegalArgumentException with a nice message.