### PR TITLE
Publish build scans in case of failures

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,6 +55,17 @@ dependencyResolutionManagement {
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.9.0")
+    id("com.gradle.develocity") version "3.19"
+}
+
+develocity {
+    buildScan {
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
+        publishing.onlyIf {
+            System.getenv("GITHUB_ACTIONS") == "true" && it.buildResult.failures.isNotEmpty()
+        }
+    }
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Helpful with troubleshooting failed builds, especially if they failed on a runner that one doesn't have available.

A direct motivation for it are failing tests in https://github.com/krzema12/snakeyaml-engine-kmp/pull/324. However, the issue is weird there: if I enable build scans in that PR, the tests pass. Adding the build scans in general is a good thing, so here's a separate PR.