### PR TITLE
Fix caching for generating test resources accessor

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/multiplatform-test-resources.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/multiplatform-test-resources.gradle.kts
@@ -13,5 +13,8 @@ val convertCommonTestResourcesToKotlin by tasks.registering(buildsrc.tasks.Conve
     description = "Generate Kotlin code for accessing the common test resources"
     group = "verification"
 
+    // HACK: Ideally we'd retrieve the 'resources' path via Gradle API, but somehow Gradle sees only 'main' and 'test'
+    // source sets instead of the required 'commonTest'.
+    commonResourcesDir.set(project.projectDir.resolve("src").resolve("commonTest").resolve("resources"))
     destination.set(layout.buildDirectory.dir("generated-code-for-resources/src/commonTest/kotlin"))
 }


### PR DESCRIPTION
Thanks to this fix, the accessor class is regenerated if the resources dir's content changes.

Closes https://github.com/krzema12/snakeyaml-engine-kmp/issues/327.