### PR TITLE
performance: avoid making codepoints window copy on prefix call

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
@@ -22,6 +22,7 @@ import it.krzeminski.snakeyaml.engine.kmp.common.CharConstants
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.Mark
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.ReaderException
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.YamlEngineException
+import it.krzeminski.snakeyaml.engine.kmp.internal.utils.appendCodePoint
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 
@@ -158,9 +159,11 @@ class StreamReader(
             else                     -> length.coerceAtMost(dataLength - pointer)
         }
 
-        return codePointsWindow
-            .copyOfRangeSafe(pointer, pointer + stringLength)
-            .joinToString("") { Character.toChars(it).concatToString() }
+        return buildString(stringLength) {
+            for (i in pointer until pointer + stringLength) {
+                appendCodePoint(codePointsWindow[i])
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
I noticed that we make a copy of a codepoint window when `prefix(int)` method is called. It looks redundant since the `StreamReader` should not be invoked from different threads and the resulting `String` is immutable.

I have changed the code build string without making a copy and got a significant performance increase on local benchmarks (let see how it behaves in CI)

```text
Benchmark                                                 Mode  Cnt   Score   Error  Units
LoadingTimeBenchmark.loadsOpenAiSchema                    avgt   10  15.655 ± 0.138  ms/op
SnakeyamlEngineJvmLoadingTimeBenchmark.loadsOpenAiSchema  avgt   10  13.554 ± 0.348  ms/op
```

Related to #266 