### PR TITLE
performance: avoid boxing when making array's copy

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
@@ -282,6 +282,6 @@ class StreamReader(
          * Like [IntArray.copyOfRange], but allows for [toIndex] to be out-of-bounds.
          */
         private fun IntArray.copyOfRangeSafe(fromIndex: Int, toIndex: Int): IntArray =
-            IntArray(toIndex - fromIndex) { getOrNull(fromIndex + it) ?: 0 }
+            IntArray(toIndex - fromIndex) { getOrElse(fromIndex + it) { 0 } }
     }
 }


### PR DESCRIPTION
A small optimization to avoid creating an `Integer` object. Method `getOrNull` must return an object since it can return a `null` value. Using `getOrElse` will always return a primitive value. It is not much but it is something (until I figure out what to do with `StreamReader.update` method)

Related to #266 