### PR TITLE
Fix reading env vars for JS and WASM JS (only NodeJS)

### DIFF
--- a/src/jsCommonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/system.js.kt
+++ b/src/jsCommonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/system.js.kt
@@ -1,6 +1,0 @@
-package it.krzeminski.snakeyaml.engine.kmp.internal
-
-internal actual fun getEnvironmentVariable(key: String): String? {
-    // TODO how can environment variables be implemented in Kotlin/JS?
-    return null
-}

--- a/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/process.kt
+++ b/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/process.kt
@@ -1,0 +1,7 @@
+package it.krzeminski.snakeyaml.engine.kmp.internal
+
+external val process: Process
+
+external interface Process {
+    val env: dynamic
+}

--- a/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/process.kt
+++ b/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/process.kt
@@ -1,7 +1,0 @@
-package it.krzeminski.snakeyaml.engine.kmp.internal
-
-external val process: Process
-
-external interface Process {
-    val env: dynamic
-}

--- a/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/system.js.kt
+++ b/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/system.js.kt
@@ -4,6 +4,12 @@ internal actual fun getEnvironmentVariable(key: String): String? {
     return process.env[key] as String?
 }
 
+private external val process: Process
+
+private external interface Process {
+    val env: dynamic
+}
+
 //region Identity hash code
 // https://github.com/korlibs/korge/blob/60af53460dd2d68b6ac86cf459d82434e74be629/kds/src/jsMain/kotlin/korlibs/datastructure/internal/InternalJs.kt
 

--- a/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/system.js.kt
+++ b/src/jsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/system.js.kt
@@ -1,5 +1,8 @@
 package it.krzeminski.snakeyaml.engine.kmp.internal
 
+internal actual fun getEnvironmentVariable(key: String): String? {
+    return process.env[key] as String?
+}
 
 //region Identity hash code
 // https://github.com/korlibs/korge/blob/60af53460dd2d68b6ac86cf459d82434e74be629/kds/src/jsMain/kotlin/korlibs/datastructure/internal/InternalJs.kt

--- a/src/wasmJsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/system.wasm.kt
+++ b/src/wasmJsMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/system.wasm.kt
@@ -1,5 +1,9 @@
 package it.krzeminski.snakeyaml.engine.kmp.internal
 
+internal actual fun getEnvironmentVariable(key: String): String? {
+    js("return process.env[key]")
+}
+
 //region Identity hash code
 internal actual fun objectIdentityHashCode(any: Any): IdentityHashCode {
     val ref = any.toJsReference()


### PR DESCRIPTION
While working on https://github.com/krzema12/snakeyaml-engine-kmp/pull/332, I found out that the implementations for JS and WASM JS are missing. This PR focuses on adding them. I don't want to add these in the PR that is related solely to kotlinizing and commonizing the tests to give this fix a proper visibility in the release notes.

This change was tested within https://github.com/krzema12/snakeyaml-engine-kmp/pull/332, and the goal is to merge that PR soon after this one lands.

Note: env vars work only in a non-browser environment.