### PR TITLE
Re-enable WASM JS tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,4 @@
 import buildsrc.utils.configureGradleDaemonJvm
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 
 plugins {
     buildsrc.conventions.lang.`kotlin-multiplatform`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,10 +24,6 @@ kotlin {
             dependencies {
                 implementation("com.squareup.okio:okio:3.9.1")
                 implementation("net.thauvin.erik.urlencoder:urlencoder-lib:1.6.0")
-                // Overridig coroutines' version to solve a problem with WASM JS tests.
-                // See https://kotlinlang.slack.com/archives/CDFP59223/p1736191408326039?thread_ts=1734964013.996149&cid=CDFP59223
-                // TODO: remove this workaround in https://github.com/krzema12/snakeyaml-engine-kmp/issues/337
-                runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
             }
         }
 
@@ -41,6 +37,10 @@ kotlin {
                 implementation("io.kotest:kotest-framework-engine:6.0.0.M1")
                 implementation("io.kotest:kotest-framework-api:6.0.0.M1")
                 implementation("io.kotest:kotest-assertions-core:6.0.0.M1")
+                // Overridig coroutines' version to solve a problem with WASM JS tests.
+                // See https://kotlinlang.slack.com/archives/CDFP59223/p1736191408326039?thread_ts=1734964013.996149&cid=CDFP59223
+                // TODO: remove this workaround in https://github.com/krzema12/snakeyaml-engine-kmp/issues/337
+                runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
             dependencies {
                 implementation("com.squareup.okio:okio:3.9.1")
                 implementation("net.thauvin.erik.urlencoder:urlencoder-lib:1.6.0")
+                runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,10 +60,6 @@ tasks.withType<Test>().configureEach {
     )
 }
 
-rootProject.plugins.withType<NodeJsRootPlugin> {
-    rootProject.the<NodeJsRootExtension>().versions.karma.version = "6.4.3"
-}
-
 dokkatoo {
     moduleName = "SnakeYAML Engine KMP"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,9 @@ kotlin {
             dependencies {
                 implementation("com.squareup.okio:okio:3.9.1")
                 implementation("net.thauvin.erik.urlencoder:urlencoder-lib:1.6.0")
+                // Overridig coroutines' version to solve a problem with WASM JS tests.
+                // See https://kotlinlang.slack.com/archives/CDFP59223/p1736191408326039?thread_ts=1734964013.996149&cid=CDFP59223
+                // TODO: remove this workaround in https://github.com/krzema12/snakeyaml-engine-kmp/issues/337
                 runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import buildsrc.utils.configureGradleDaemonJvm
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 
 plugins {
     buildsrc.conventions.lang.`kotlin-multiplatform`
@@ -55,6 +57,10 @@ tasks.withType<Test>().configureEach {
         "EnvironmentKey1" to "EnvironmentValue1",
         "EnvironmentEmpty" to "",
     )
+}
+
+rootProject.plugins.withType<NodeJsRootPlugin> {
+    rootProject.the<NodeJsRootExtension>().versions.karma.version = "6.4.3"
 }
 
 dokkatoo {

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
@@ -49,20 +49,8 @@ kotlin {
     //region Wasm Targets
     wasmJs {
         binaries.library()
-        browser {
-            testTask {
-                // Disabled to unblock releasing of the lib.
-                // See https://github.com/krzema12/snakeyaml-engine-kmp/issues/320
-                enabled = false
-            }
-        }
-        nodejs {
-            testTask {
-                // Disabled to unblock releasing of the lib.
-                // See https://github.com/krzema12/snakeyaml-engine-kmp/issues/320
-                enabled = false
-            }
-        }
+        browser()
+        nodejs()
     }
 
     // Disable Wasi: No matching variant of io.kotest:kotest-framework-engine:5.9.0 was found

--- a/gradle/kotlin-js-store/yarn.lock
+++ b/gradle/kotlin-js-store/yarn.lock
@@ -1108,10 +1108,10 @@ karma-webpack@5.0.1:
     minimatch "^9.0.3"
     webpack-merge "^4.1.5"
 
-karma@6.4.4:
-  version "6.4.4"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.4.tgz#dfa5a426cf5a8b53b43cd54ef0d0d09742351492"
-  integrity sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==
+karma@6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.3.tgz#763e500f99597218bbb536de1a14acc4ceea7ce8"
+  integrity sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"

--- a/gradle/kotlin-js-store/yarn.lock
+++ b/gradle/kotlin-js-store/yarn.lock
@@ -1108,10 +1108,10 @@ karma-webpack@5.0.1:
     minimatch "^9.0.3"
     webpack-merge "^4.1.5"
 
-karma@6.4.3:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.3.tgz#763e500f99597218bbb536de1a14acc4ceea7ce8"
-  integrity sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==
+karma@6.4.4:
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.4.tgz#dfa5a426cf5a8b53b43cd54ef0d0d09742351492"
+  integrity sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"


### PR DESCRIPTION
Closes #320.

Related to https://kotlinlang.slack.com/archives/CDFP59223/p1736171757249559?thread_ts=1734964013.996149&cid=CDFP59223

> The problem in linkage of coroutines 1.8.0 (which was built against Kotlin/Wasm 1.9.21) with Kotlin stdlib 2.1.0.
In 2.1.0 we have some changes in our linkage process (including changes in stdlib), so I’d recommend to use new Kotlin coroutines which was built with Kotlin 2.1.0
For example the latest one with version 1.10.1