### PR TITLE
Renovate: ignore test resources

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,7 @@
   ],
   ignorePaths: [
     'src/jvmTest/resources/',
+    'src/commonTest/resources/',
   ],
   automerge: true,
 }


### PR DESCRIPTION
We don't need to bump deps in the test resources, like:

* https://github.com/krzema12/snakeyaml-engine-kmp/pull/342
* https://github.com/krzema12/snakeyaml-engine-kmp/pull/343

These updates appeared as we started moving the test resources to the common source set, so now we need to ignore yet another dir by Renovate.