### PR TITLE
Add leading slash in path to common test resources

### DIFF
--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
@@ -6,12 +6,13 @@ import okio.ByteString
 /**
  * Retrieves a string content from common resources using a given path.
  *
- * @param path The slash-delimited path to the resource.
+ * @param path The slash-delimited path to the resource, with a leading slash.
  * @return The content of the resource as a UTF-8 encoded string with normalized line breaks.
  * @throws IllegalArgumentException if the resource doesn't exist.
  */
 fun stringFromResources(path: String): String {
-    val segments = path.split("/")
+    require(path.startsWith("/")) { "A leading slash is required!" }
+    val segments = path.drop(1).split("/")
     return (segments
         .dropLast(1)
         .fold(Pair(CommonTestResources.resourcesMap, "/resources/")) { (map, pathSoFar), directory ->

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 
 class CommonTestResourcesAccessTest : FunSpec({
     test("stringFromResources - resource exists") {
-        stringFromResources("test/resource/foo.txt") shouldBe """
+        stringFromResources("/test/resource/foo.txt") shouldBe """
             Hello from multiplatform resources!
             Foo bar baz
 
@@ -15,7 +15,7 @@ class CommonTestResourcesAccessTest : FunSpec({
 
     test("stringFromResources - file doesn't exist") {
         shouldThrow<IllegalArgumentException> {
-            stringFromResources("test/resource/does-not-exist.txt")
+            stringFromResources("/test/resource/does-not-exist.txt")
         }.also {
             it.message shouldBe "File 'does-not-exist.txt' doesn't exist in directory '/resources/test/resource/'!"
         }
@@ -23,9 +23,17 @@ class CommonTestResourcesAccessTest : FunSpec({
 
     test("stringFromResources - directory doesn't exist") {
         shouldThrow<IllegalArgumentException> {
-            stringFromResources("this/resource/for/sure/does/not/exist.txt")
+            stringFromResources("/this/resource/for/sure/does/not/exist.txt")
         }.also {
             it.message shouldBe "Directory 'this' doesn't exist in directory '/resources/'!"
+        }
+    }
+
+    test("stringFromResources - no leading slash") {
+        shouldThrow<IllegalArgumentException> {
+            stringFromResources("test/resource/foo.txt")
+        }.also {
+            it.message shouldBe "A leading slash is required!"
         }
     }
 })

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadMappingTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadMappingTest.kt
@@ -29,7 +29,7 @@ class LoadMappingTest: FunSpec({
     test("map {x: 1, y: 2, z:3} is parsed") {
         val load = Load()
         @Suppress("UNCHECKED_CAST")
-        val map = load.loadOne(stringFromResources("load/map1.yaml")) as Map<String, Any>
+        val map = load.loadOne(stringFromResources("/load/map1.yaml")) as Map<String, Any>
         map shouldBe mapOf("x" to 1, "y" to 2, "z" to 3)
     }
 })

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadSequenceTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadSequenceTest.kt
@@ -37,7 +37,7 @@ class LoadSequenceTest : FunSpec({
     test("list is parsed") {
         val load = Load()
         @Suppress("UNCHECKED_CAST")
-        val list = load.loadOne(stringFromResources("load/list1.yaml")) as List<Any>
+        val list = load.loadOne(stringFromResources("/load/list1.yaml")) as List<Any>
         list shouldBe listOf("a", "bb", "ccc", "dddd")
     }
 })

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue149/GlobalDirectivesTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue149/GlobalDirectivesTest.kt
@@ -18,12 +18,12 @@ class GlobalDirectivesTest : FunSpec({
     }
 
     test("Use tag directive") {
-        val events = yamlToEvents("issues/issue149-one-document.yaml")
+        val events = yamlToEvents("/issues/issue149-one-document.yaml")
         events.toList().size shouldBe 10
     }
 
     test("Fail to parse because directive does not stay for the second document") {
-        val events = yamlToEvents("issues/issue149-losing-directives.yaml")
+        val events = yamlToEvents("/issues/issue149-losing-directives.yaml")
         shouldThrow<ParserException> {
             events.toList()
         }.also {
@@ -32,7 +32,7 @@ class GlobalDirectivesTest : FunSpec({
     }
 
     test("Parse both tag directives") {
-        val events = yamlToEvents("issues/issue149-losing-directives-2.yaml")
+        val events = yamlToEvents("/issues/issue149-losing-directives-2.yaml")
         events.toList().size shouldBe 18
     }
 })

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue39/EmitCommentAndSpacesTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue39/EmitCommentAndSpacesTest.kt
@@ -17,7 +17,7 @@ import it.krzeminski.snakeyaml.engine.kmp.stringFromResources
 class EmitCommentAndSpacesTest : FunSpec({
     test("Issue 39: extra space added") {
         val loadSettings = LoadSettings.builder().setParseComments(true).build()
-        val input = stringFromResources("issues/issue39-input.yaml")
+        val input = stringFromResources("/issues/issue39-input.yaml")
         val parser = ParserImpl(loadSettings, StreamReader(loadSettings, input))
         val settings = DumpSettings.builder().setDumpComments(true).build()
         val writer = StringStreamDataWriter()

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/env/EnvVariableTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/env/EnvVariableTest.kt
@@ -22,7 +22,7 @@ class EnvVariableTest : FunSpec({
 
     test("Parse docker-compose.yaml example").config(enabled = areEnvVarsSupported()) {
         val loader = Load(LoadSettings.builder().setEnvConfig(NULL_ENV_CONFIG).build())
-        val resource = stringFromResources("env/docker-compose.yaml")
+        val resource = stringFromResources("/env/docker-compose.yaml")
         @Suppress("UNCHECKED_CAST")
         val compose = loader.loadOne(resource) as Map<String, Any>
         val output = compose.toString()

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/indentation/IndentWithIndicatorTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/indentation/IndentWithIndicatorTest.kt
@@ -18,7 +18,7 @@ class IndentWithIndicatorTest : FunSpec({
         val dumper = Dump(settings)
         val output = dumper.dumpToString(DATA)
 
-        val doc = stringFromResources("indentation/issue416-1.yaml")
+        val doc = stringFromResources("/indentation/issue416-1.yaml")
         output shouldBe doc
     }
 
@@ -32,7 +32,7 @@ class IndentWithIndicatorTest : FunSpec({
         val dumper = Dump(settings)
         val output = dumper.dumpToString(DATA)
 
-        val doc = stringFromResources("indentation/issue416-2.yaml")
+        val doc = stringFromResources("/indentation/issue416-2.yaml")
         output shouldBe doc
     }
 
@@ -46,7 +46,7 @@ class IndentWithIndicatorTest : FunSpec({
         val dumper = Dump(settings)
         val output = dumper.dumpToString(DATA)
 
-        val doc = stringFromResources("indentation/issue416-3.yaml")
+        val doc = stringFromResources("/indentation/issue416-3.yaml")
         output shouldBe doc
     }
 })

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/references/DereferenceAliasesTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/references/DereferenceAliasesTest.kt
@@ -15,19 +15,19 @@ class DereferenceAliasesTest : FunSpec({
     test("no aliases") {
         val settings = LoadSettings.builder().build()
         val load = Load(settings)
-        val map = load.loadOne(stringFromResources("issues/issue1086-1-input.yaml")) as Map<*, *>?
+        val map = load.loadOne(stringFromResources("/issues/issue1086-1-input.yaml")) as Map<*, *>?
         val setting = DumpSettings.builder().setDefaultFlowStyle(FlowStyle.BLOCK)
             .setDereferenceAliases(true).build()
         val dump = Dump(setting)
         val node = dump.dumpToString(map)
-        val expected = stringFromResources("issues/issue1086-1-expected.yaml")
+        val expected = stringFromResources("/issues/issue1086-1-expected.yaml")
         node shouldBe expected
     }
 
     test("no aliases recursive") {
         val settings = LoadSettings.builder().build()
         val load = Load(settings)
-        val map = load.loadOne(stringFromResources("issues/issue1086-2-input.yaml")) as Map<*, *>?
+        val map = load.loadOne(stringFromResources("/issues/issue1086-2-input.yaml")) as Map<*, *>?
         val setting = DumpSettings.builder().setDefaultFlowStyle(FlowStyle.BLOCK)
             .setDereferenceAliases(true).build()
         val dump = Dump(setting)

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/references/DumpAnchorTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/references/DumpAnchorTest.kt
@@ -13,7 +13,7 @@ import it.krzeminski.snakeyaml.engine.kmp.stringFromResources
 
 class DumpAnchorTest : FunSpec({
     test("anchor test") {
-        val str = stringFromResources("anchor/issue481.yaml")
+        val str = stringFromResources("/anchor/issue481.yaml")
         val compose = Compose(LoadSettings.builder().build())
         val node = compose.compose(str)!!
 

--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/env/EnvVariableJvmTest.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/env/EnvVariableJvmTest.kt
@@ -40,7 +40,7 @@ class EnvVariableJvmTest : FunSpec({
                 )
             ).build()
         )
-        val resource = stringFromResources("env/docker-compose.yaml")
+        val resource = stringFromResources("/env/docker-compose.yaml")
         @Suppress("UNCHECKED_CAST")
         val compose = loader.loadOne(resource) as Map<String, Any>?
         val output = compose.toString()


### PR DESCRIPTION
Thanks to this, we'll be able to use `@Language("file-reference")` to validate the paths in the IDE. Now it's impossible due to a bug in the library that provides the annotation, see https://github.com/JetBrains/java-annotations/issues/116.

This PR is a mergeable part of https://github.com/krzema12/snakeyaml-engine-kmp/pull/349.