### PR TITLE
Allow larger common test resources

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/tasks/ConvertCommonTestResourcesToKotlin.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/tasks/ConvertCommonTestResourcesToKotlin.kt
@@ -74,7 +74,7 @@ abstract class ConvertCommonTestResourcesToKotlin @Inject constructor(
     }
 
     private fun generateFunctions(map: Map<String, Any>, stringBuilder: StringBuilder, path: String = "") {
-        stringBuilder.appendLine(generateSingleFunction(map, path))
+        stringBuilder.generateSingleFunction(map, path)
         stringBuilder.appendLine()
         for ((key, value) in map) {
             when (value) {
@@ -89,12 +89,13 @@ abstract class ConvertCommonTestResourcesToKotlin @Inject constructor(
         }
     }
 
-    private fun generateSingleFunction(map: Map<String, Any>, path: String): String {
+    private fun StringBuilder.generateSingleFunction(map: Map<String, Any>, path: String) {
         val functionName = getFunctionName(path)
-        return map.entries.joinToString(
+        map.entries.joinTo(
+            this,
             separator = ",\n",
             prefix = "fun ${functionName}() = mapOf(\n",
-            postfix = "\n)",
+            postfix = "\n)\n",
         ) { (key, _) ->
             "\"$key\" to ${getFunctionName("$path/$key")}()"
         }

--- a/buildSrc/src/main/kotlin/buildsrc/tasks/ConvertCommonTestResourcesToKotlin.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/tasks/ConvertCommonTestResourcesToKotlin.kt
@@ -74,7 +74,8 @@ abstract class ConvertCommonTestResourcesToKotlin @Inject constructor(
     }
 
     private fun generateFunctions(map: Map<String, Any>, stringBuilder: StringBuilder, path: String = "") {
-        stringBuilder.append(generateSingleFunction(map, path))
+        stringBuilder.appendLine(generateSingleFunction(map, path))
+        stringBuilder.appendLine()
         for ((key, value) in map) {
             when (value) {
                 is ByteArray -> stringBuilder.append("fun ${getFunctionName("$path/$key")}() = ByteString.of(${value.joinToString(separator = ", ") {


### PR DESCRIPTION
Part of https://github.com/krzema12/snakeyaml-engine-kmp/issues/354

Before this change, the build logic took all test resources, and converted them into Kotlin code that was building a map using a single expression with using nested `mapOf` function to represent the directory structure. However, when trying to move existing JVM-specific resources (there's a lot of them), one could see a failing build with:

```
exception: java.lang.RuntimeException: Error generating class file CommonTestResources.class (compiled from [/Users/piotr/repos/snakeyaml-engine-kmp/build/generated-code-for-resources/src/commonTest/kotlin/CommonTestResources.kt]): Method too large: CommonTestResources.<clinit> ()V
e
```

This change puts every call to `mapOf(...)` or `ByteString.of(...)` into a separate method, so that now the limitation is either the maximum number of files/directories in a given directory, or size of a single file. It should unblock migrating tests to the common source set that rely on the large number of files (see a work-in-progress PR: https://github.com/krzema12/snakeyaml-engine-kmp/pull/356).

It was still faster to not use KotlinPoet, but the generated code became even more ugly. It's likely that I'm going to use KotlinPoet, especially that I'm planning to extract this functionality into a library.