### PR TITLE
Add assertion to DumpWithoutCommentsTest

### DIFF
--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue53/DumpWithoutCommentsTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue53/DumpWithoutCommentsTest.kt
@@ -22,15 +22,18 @@ class DumpWithoutCommentsTest : FunSpec({
         val yaml = "a: 1 # A\nb: 2 # B\n"
         val dumpSettings = DumpSettings.builder().setDumpComments(false).build()
 
+        val streamWriter = StringStreamDataWriter()
         val emitter = Emitter(
             dumpSettings,
-            StringStreamDataWriter(),
+            streamWriter,
         )
         val serializer = Serializer(dumpSettings, emitter)
 
         serializer.emitStreamStart()
         serializer.serializeDocument(createNodeWithComments(yaml))
         serializer.emitStreamEnd()
+
+        streamWriter.toString() shouldBe "a: 1\nb: 2\n"
     }
 
     test("check no comments") {


### PR DESCRIPTION
Closes https://github.com/krzema12/snakeyaml-engine-kmp/issues/317.

Let's have this basic assertion, so that this test doesn't only rely on certain function calls not throwing exceptions.