### PR TITLE
Use Okio in inherited tests

### DIFF
--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/internal/FSPath.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/internal/FSPath.kt
@@ -1,0 +1,46 @@
+package it.krzeminski.snakeyaml.engine.kmp.internal
+
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.Source
+
+/**
+ * Represents a [FileSystem]-aware [Path]. Thanks to this, there's no need
+ * to keep writing e.g. `FileSystem.SYSTEM.exists("foobar".toPath())`, and
+ * repeat the "file system" part. The file system becomes a part of the path,
+ * allowing more concise and abstract code - specifying the file system is
+ * required only once, at the beginning of operating on the path.
+ */
+class FSPath(val path: Path, val fs: FileSystem) {
+    val name: String
+        get() = path.name
+
+    val parent: FSPath?
+        get() = path.parent?.let { FSPath(it, fs) }
+
+    val exists: Boolean
+        get() = fs.exists(path)
+
+    val isDirectory: Boolean
+        get() = fs.metadataOrNull(path)?.isDirectory == true
+
+    val isRegularFile: Boolean
+        get() = fs.metadataOrNull(path)?.isRegularFile == true
+
+    fun listRecursively(): Sequence<FSPath> =
+        fs.listRecursively(path)
+            .map { FSPath(it, fs) }
+
+    fun resolve(child: String): FSPath =
+        FSPath(path.resolve(child), fs)
+
+    fun source(): Source =
+        fs.source(path)
+
+    override fun toString(): String =
+        path.toString()
+}
+
+fun FileSystem.fsPath(path: String): FSPath =
+    FSPath(path.toPath(), this)

--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedCanonicalTest.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedCanonicalTest.kt
@@ -5,18 +5,14 @@ import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import it.krzeminski.snakeyaml.engine.kmp.tokens.Token
 import okio.BufferedSource
-import okio.FileSystem
-import okio.Source
 import okio.buffer
-import java.io.InputStream
-import java.nio.file.Files
 
 class InheritedCanonicalTest: FunSpec({
     test("Canonical scan") {
         val files = getStreamsByExtension(".canonical")
         files.size shouldBeGreaterThan 0
         files.forEach { file ->
-            FileSystem.SYSTEM.source(file).use { input ->
+            file.source().use { input ->
                 val tokens = canonicalScan(input.buffer(), file.name)
                 tokens.shouldNotBeEmpty()
             }
@@ -27,7 +23,7 @@ class InheritedCanonicalTest: FunSpec({
         val files = getStreamsByExtension(".canonical")
         files.size shouldBeGreaterThan 0
         files.forEach { file ->
-            FileSystem.SYSTEM.source(file).use { input ->
+            file.source().use { input ->
                 val tokens = canonicalParse(input, file.name)
                 tokens.shouldNotBeEmpty()
             }

--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedCanonicalTest.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedCanonicalTest.kt
@@ -37,10 +37,9 @@ class InheritedCanonicalTest: FunSpec({
 
 private fun canonicalScan(input: BufferedSource, label: String): List<Token> {
     val buffer = buildString {
-        var ch = input.readUtf8CodePoint()
-        while (ch != -1) {
+        while (input.exhausted()) {
+            var ch = input.readByte().toInt()
             append(ch.toChar())
-            ch = input.readUtf8CodePoint()
         }
     }
     val scanner = CanonicalScanner(buffer.toString().replace(System.lineSeparator(), "\n"), label)

--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedImportUtils.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedImportUtils.kt
@@ -5,11 +5,11 @@ import it.krzeminski.snakeyaml.engine.kmp.api.YamlUnicodeReader
 import it.krzeminski.snakeyaml.engine.kmp.events.Event
 import it.krzeminski.snakeyaml.engine.kmp.parser.ParserImpl
 import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
-import okio.source
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.Source
 import org.snakeyaml.engine.v2.utils.TestUtils
-import java.io.File
-import java.io.FilenameFilter
-import java.io.InputStream
 
 private const val PATH =  "/inherited_yaml_1_1"
 
@@ -20,22 +20,26 @@ fun getResource(theName: String): String =
 fun getStreamsByExtension(
     extension: String,
     onlyIfCanonicalPresent: Boolean = false,
-): Array<File> =
-    File("src/jvmTest/resources$PATH").also {
-        require(it.exists()) { "Folder not found: ${it.absolutePath}" }
-        require(it.isDirectory)
-    }.listFiles(InheritedFilenameFilter(extension, onlyIfCanonicalPresent))
-
-fun getFileByName(name: String): File =
-    File("src/jvmTest/resources$PATH/$name").also {
-        require(it.exists()) { "Folder not found: ${it.absolutePath}" }
-        require(it.isFile)
+): List<Path> =
+    "src/jvmTest/resources$PATH".toPath().also {
+        require(FileSystem.SYSTEM.exists(it)) { "Folder not found: $it" }
+        require(FileSystem.SYSTEM.metadataOrNull(it)?.isDirectory == true)
+    }.let {
+        FileSystem.SYSTEM.listRecursively(it)
+            .filter { FileSystem.SYSTEM.inheritedFilenameFilter(it, extension, onlyIfCanonicalPresent) }
+            .toList()
     }
 
-fun canonicalParse(input2: InputStream, label: String): List<Event> {
+fun getFileByName(name: String): Path =
+    "src/jvmTest/resources$PATH/$name".toPath().also {
+        require(FileSystem.SYSTEM.exists(it)) { "File not found: $it" }
+        require(FileSystem.SYSTEM.metadataOrNull(it)?.isRegularFile == true)
+    }
+
+fun canonicalParse(input2: Source, label: String): List<Event> {
     val settings = LoadSettings.builder().setLabel(label).build()
     input2.use {
-        val reader = StreamReader(settings, YamlUnicodeReader(input2.source()))
+        val reader = StreamReader(settings, YamlUnicodeReader(input2))
         val buffer = StringBuffer()
         while (reader.peek() != 0) {
             buffer.appendCodePoint(reader.peek())
@@ -51,10 +55,10 @@ fun canonicalParse(input2: InputStream, label: String): List<Event> {
     }
 }
 
-fun parse(input: InputStream): List<Event> {
+fun parse(input: Source): List<Event> {
     val settings = LoadSettings.builder().build()
     input.use {
-        val reader = StreamReader(settings, YamlUnicodeReader(input.source()))
+        val reader = StreamReader(settings, YamlUnicodeReader(input))
         val parser = ParserImpl(settings, reader)
         val result = buildList {
             while (parser.hasNext()) {
@@ -65,18 +69,19 @@ fun parse(input: InputStream): List<Event> {
     }
 }
 
-private class InheritedFilenameFilter(
-    private val extension: String,
-    private val onlyIfCanonicalPresent: Boolean,
-) : FilenameFilter {
-    override fun accept(dir: File?, name: String): Boolean {
-        val position = name.lastIndexOf('.')
-        val canonicalFileName = name.substring(0, position) + ".canonical"
-        val canonicalFile = File(dir, canonicalFileName)
-        return if (onlyIfCanonicalPresent && !canonicalFile.exists()) {
-            false
-        } else {
-            name.endsWith(extension)
-        }
+private fun FileSystem.inheritedFilenameFilter(
+    path: Path,
+    extension: String,
+    onlyIfCanonicalPresent: Boolean,
+): Boolean {
+    val name = path.name
+    val position = name.lastIndexOf('.')
+    val canonicalFileName = name.substring(0, position) + ".canonical"
+    val canonicalFilePath = path.parent?.resolve(canonicalFileName)
+        ?: error("Canonical file path does not exist: $path")
+    return if (onlyIfCanonicalPresent && this.exists(canonicalFilePath)) {
+        false
+    } else {
+        name.endsWith(extension)
     }
 }

--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedImportUtils.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedImportUtils.kt
@@ -79,7 +79,7 @@ private fun FileSystem.inheritedFilenameFilter(
     val canonicalFileName = name.substring(0, position) + ".canonical"
     val canonicalFilePath = path.parent?.resolve(canonicalFileName)
         ?: error("Canonical file path does not exist: $path")
-    return if (onlyIfCanonicalPresent && this.exists(canonicalFilePath)) {
+    return if (onlyIfCanonicalPresent && !this.exists(canonicalFilePath)) {
         false
     } else {
         name.endsWith(extension)

--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedReaderTest.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedReaderTest.kt
@@ -18,17 +18,19 @@ class InheritedReaderTest: FunSpec({
             // KMP basically only supports UTF-8.
             .filter { it.name !in setOf("odd-utf16.stream-error", "invalid-utf8-byte.stream-error") }
             .forEach { input ->
-                val unicodeReader = YamlUnicodeReader(input.source())
-                val stream = StreamReader(LoadSettings.builder().build(), unicodeReader)
-                try {
-                    while (stream.peek() != 0) {
-                        stream.forward()
+                input.source().use { source ->
+                    val unicodeReader = YamlUnicodeReader(source)
+                    val stream = StreamReader(LoadSettings.builder().build(), unicodeReader)
+                    try {
+                        while (stream.peek() != 0) {
+                            stream.forward()
+                        }
+                        fail("Invalid stream must not be accepted: $input; encoding=${unicodeReader.encoding}")
+                    } catch (e: ReaderException) {
+                        e.toString() shouldContain " special characters are not allowed"
+                    } catch (e: YamlEngineException) {
+                        e.toString() shouldContain " MalformedInputException"
                     }
-                    fail("Invalid stream must not be accepted: $input; encoding=${unicodeReader.encoding}")
-                } catch (e: ReaderException) {
-                    e.toString() shouldContain " special characters are not allowed"
-                } catch (e: YamlEngineException) {
-                    e.toString() shouldContain " MalformedInputException"
                 }
             }
     }

--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedReaderTest.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedReaderTest.kt
@@ -8,7 +8,6 @@ import it.krzeminski.snakeyaml.engine.kmp.api.YamlUnicodeReader
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.ReaderException
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.YamlEngineException
 import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
-import okio.FileSystem
 
 class InheritedReaderTest: FunSpec({
     test("Reader errors") {
@@ -19,7 +18,7 @@ class InheritedReaderTest: FunSpec({
             // KMP basically only supports UTF-8.
             .filter { it.name !in setOf("odd-utf16.stream-error", "invalid-utf8-byte.stream-error") }
             .forEach { input ->
-                val unicodeReader = YamlUnicodeReader(FileSystem.SYSTEM.source(input))
+                val unicodeReader = YamlUnicodeReader(input.source())
                 val stream = StreamReader(LoadSettings.builder().build(), unicodeReader)
                 try {
                     while (stream.peek() != 0) {

--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedTokensTest.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedTokensTest.kt
@@ -73,7 +73,7 @@ class InheritedTokensTest: FunSpec({
                     println("Data: \n$data")
                     println("Tokens:")
                     tokens1.forEach {
-                        println("token")
+                        println(it)
                     }
                     fail("Cannot scan: $tokenFile")
                 }
@@ -101,7 +101,7 @@ class InheritedTokensTest: FunSpec({
                     println("Data: \n$data")
                     println("Tokens:")
                     tokens.forEach {
-                        println("token")
+                        println(it)
                     }
                     fail("Cannot scan: $file; ${e.message}")
                 }

--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedTokensTest.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedTokensTest.kt
@@ -11,7 +11,6 @@ import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
 import it.krzeminski.snakeyaml.engine.kmp.tokens.StreamEndToken
 import it.krzeminski.snakeyaml.engine.kmp.tokens.StreamStartToken
 import it.krzeminski.snakeyaml.engine.kmp.tokens.Token
-import okio.FileSystem
 
 class InheritedTokensTest: FunSpec({
     test("Tokens are correct") {
@@ -52,7 +51,7 @@ class InheritedTokensTest: FunSpec({
 
             val tokens1 = mutableListOf<String>()
             val settings = LoadSettings.builder().build()
-            FileSystem.SYSTEM.source(getFileByName(dataName)).use { source ->
+            getFileByName(dataName).source().use { source ->
                 val reader = StreamReader(
                     loadSettings = settings,
                     stream = YamlUnicodeReader(source),
@@ -86,7 +85,7 @@ class InheritedTokensTest: FunSpec({
         files.size shouldBeGreaterThan 0
         files.forEach { file ->
             val tokens = mutableListOf<String>()
-            FileSystem.SYSTEM.source(file).use { source ->
+            file.source().use { source ->
                 val settings = LoadSettings.builder().build()
                 val reader = StreamReader(settings, YamlUnicodeReader(source))
                 val scanner = ScannerImpl(settings, reader)

--- a/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedTokensTest.kt
+++ b/src/jvmTest/java/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedTokensTest.kt
@@ -11,8 +11,7 @@ import it.krzeminski.snakeyaml.engine.kmp.scanner.StreamReader
 import it.krzeminski.snakeyaml.engine.kmp.tokens.StreamEndToken
 import it.krzeminski.snakeyaml.engine.kmp.tokens.StreamStartToken
 import it.krzeminski.snakeyaml.engine.kmp.tokens.Token
-import okio.source
-import java.io.FileInputStream
+import okio.FileSystem
 
 class InheritedTokensTest: FunSpec({
     test("Tokens are correct") {
@@ -53,7 +52,7 @@ class InheritedTokensTest: FunSpec({
 
             val tokens1 = mutableListOf<String>()
             val settings = LoadSettings.builder().build()
-            FileInputStream(getFileByName(dataName)).source().use { source ->
+            FileSystem.SYSTEM.source(getFileByName(dataName)).use { source ->
                 val reader = StreamReader(
                     loadSettings = settings,
                     stream = YamlUnicodeReader(source),
@@ -87,7 +86,7 @@ class InheritedTokensTest: FunSpec({
         files.size shouldBeGreaterThan 0
         files.forEach { file ->
             val tokens = mutableListOf<String>()
-            FileInputStream(file).source().use { source ->
+            FileSystem.SYSTEM.source(file).use { source ->
                 val settings = LoadSettings.builder().build()
                 val reader = StreamReader(settings, YamlUnicodeReader(source))
                 val scanner = ScannerImpl(settings, reader)


### PR DESCRIPTION
Part of https://github.com/krzema12/snakeyaml-engine-kmp/issues/269.

I'm planning to implement Okio's file system to reflect the common test resources, so this refactoring brings us closer to this idea.