### PR TITLE
Implement file system based on common test resources and use it in stringFromResources

### DIFF
--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
@@ -56,7 +56,10 @@ object CommonTestResourcesFileSystem : FileSystem() {
 
     override fun source(file: Path): Source =
         traverseResourcesMap(file)?.let {
-            (Buffer().write(it as ByteString) as Source)
+            if (it !is ByteString) {
+                throw IOException("'$file' is not a file")
+            }
+            (Buffer().write(it) as Source)
         } ?: throw IOException("File '$file' doesn't exist")
 
     override fun canonicalize(path: Path): Path =

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
@@ -1,7 +1,17 @@
 package it.krzeminski.snakeyaml.engine.kmp
 
 import CommonTestResources
+import okio.Buffer
 import okio.ByteString
+import okio.FileHandle
+import okio.FileMetadata
+import okio.FileSystem
+import okio.IOException
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.Sink
+import okio.Source
+import okio.buffer
 
 /**
  * Retrieves a string content from common resources using a given path.
@@ -12,24 +22,87 @@ import okio.ByteString
  */
 fun stringFromResources(path: String): String {
     require(path.startsWith("/")) { "A leading slash is required!" }
-    val segments = path.drop(1).split("/")
-    return (segments
-        .dropLast(1)
-        .fold(Pair(CommonTestResources.resourcesMap, "/resources/")) { (map, pathSoFar), directory ->
-            require(directory in map) {
-                "Directory '$directory' doesn't exist in directory '$pathSoFar'!"
-            }
-            @Suppress("UNCHECKED_CAST")
-            Pair(map[directory] as Map<String, Any>, "$pathSoFar$directory/")
-        }).let { (map, pathSoFar) ->
-            val file = segments.last()
-            require(file in map) {
-                "File '$file' doesn't exist in directory '$pathSoFar'!"
-            }
-            map[file] as ByteString
-        }.utf8()
+    val path = path.drop(1).toPath()
+    return CommonTestResourcesFileSystem.source(path).buffer().readUtf8()
         // In this particular library, we produce uniform line breaks (\n)
         // on all OSes, hence it's desired to normalize them even if in
         // the resource file, we have a different kind of line breaks.
         .replace(Regex("\\r\\n?"), "\n")
+}
+
+/**
+ * Exposes files stored in `commonTest/resources` as a [FileSystem].
+ */
+object CommonTestResourcesFileSystem : FileSystem() {
+    override fun list(dir: Path): List<Path> =
+        listOrNull(dir) ?: throw IOException("Cannot list $dir")
+
+    override fun listOrNull(dir: Path): List<Path>? {
+        val node = traverseResourcesMap(dir) ?: return null
+        if (node !is Map<*, *>) {
+            return null
+        }
+        @Suppress("UNCHECKED_CAST")
+        return (node as Map<String, Any?>).keys.map { dir.resolve(it) }
+    }
+
+    override fun metadataOrNull(path: Path): FileMetadata? =
+        traverseResourcesMap(path)?.let { node ->
+            FileMetadata(
+                isDirectory = node is Map<*, *>,
+                isRegularFile = node !is Map<*, *>,
+            )
+        }
+
+    override fun source(file: Path): Source =
+        traverseResourcesMap(file)?.let {
+            (Buffer().write(it as ByteString) as Source)
+        } ?: throw IOException("Cannot read $file")
+
+    override fun canonicalize(path: Path): Path =
+        throw NotImplementedError("This operation is not supported by this simple implementation of the file system.")
+
+    override fun openReadOnly(file: Path): FileHandle =
+        throw NotImplementedError("This operation is not supported by this simple implementation of the file system.")
+
+    override fun openReadWrite(file: Path, mustCreate: Boolean, mustExist: Boolean): FileHandle =
+        throw NotImplementedError("This operation is not supported by this simple implementation of the file system.")
+
+    override fun sink(file: Path, mustCreate: Boolean): Sink =
+        throw NotImplementedError("This operation is not supported by this simple implementation of the file system.")
+
+    override fun appendingSink(file: Path, mustExist: Boolean): Sink =
+        throw NotImplementedError("This operation is not supported by this simple implementation of the file system.")
+
+    override fun createDirectory(dir: Path, mustCreate: Boolean) =
+        throw NotImplementedError("This operation is not supported by this simple implementation of the file system.")
+
+    override fun atomicMove(source: Path, target: Path) =
+        throw NotImplementedError("This operation is not supported by this simple implementation of the file system.")
+
+    override fun delete(path: Path, mustExist: Boolean) =
+        throw NotImplementedError("This operation is not supported by this simple implementation of the file system.")
+
+    override fun createSymlink(source: Path, target: Path) =
+        throw NotImplementedError("This operation is not supported by this simple implementation of the file system.")
+}
+
+/**
+ * Returns a map or a leaf (file) in the resources map, pointed to by [path],
+ * or `null` if the file or directory cannot be found.
+ */
+private fun traverseResourcesMap(path: Path): Any? {
+    var map: Any? = CommonTestResources.resourcesMap
+    for (segment in path.segments) {
+        if (map is Map<*, *>) {
+            if (segment in map) {
+                map = map[segment]
+            } else {
+                return null
+            }
+        } else {
+            return null
+        }
+    }
+    return map
 }

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
@@ -95,11 +95,7 @@ private fun traverseResourcesMap(path: Path): Any? {
     var map: Any? = CommonTestResources.resourcesMap
     for (segment in path.segments) {
         if (map is Map<*, *>) {
-            if (segment in map) {
-                map = map[segment]
-            } else {
-                return null
-            }
+            map = map[segment] ?: return null
         } else {
             return null
         }

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccess.kt
@@ -57,7 +57,7 @@ object CommonTestResourcesFileSystem : FileSystem() {
     override fun source(file: Path): Source =
         traverseResourcesMap(file)?.let {
             (Buffer().write(it as ByteString) as Source)
-        } ?: throw IOException("Cannot read $file")
+        } ?: throw IOException("File '$file' doesn't exist")
 
     override fun canonicalize(path: Path): Path =
         throw NotImplementedError("This operation is not supported by this simple implementation of the file system.")

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
@@ -44,7 +44,7 @@ class CommonTestResourcesAccessTest : FunSpec({
 
     test("CommonTestResourcesFileSystem - source(...) if file exists and can be read") {
         val source = CommonTestResourcesFileSystem.source("test/resource/foo.txt".toPath())
-        source.buffer().readUtf8() shouldBe """
+        source.buffer().readUtf8().lines().joinToString(separator = "\n") shouldBe """
             Hello from multiplatform resources!
             Foo bar baz
 

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
@@ -22,7 +22,7 @@ class CommonTestResourcesAccessTest : FunSpec({
         shouldThrow<IOException> {
             stringFromResources("/test/resource/does-not-exist.txt")
         }.also {
-            it.message shouldBe "Cannot read test/resource/does-not-exist.txt"
+            it.message shouldBe "File 'test/resource/does-not-exist.txt' doesn't exist"
         }
     }
 
@@ -30,7 +30,7 @@ class CommonTestResourcesAccessTest : FunSpec({
         shouldThrow<IOException> {
             stringFromResources("/this/resource/for/sure/does/not/exist.txt")
         }.also {
-            it.message shouldBe "Cannot read this/resource/for/sure/does/not/exist.txt"
+            it.message shouldBe "File 'this/resource/for/sure/does/not/exist.txt' doesn't exist"
         }
     }
 
@@ -57,7 +57,7 @@ class CommonTestResourcesAccessTest : FunSpec({
         shouldThrow<IOException> {
             CommonTestResourcesFileSystem.source("test/resource/does-not-exist.txt".toPath())
         }.also {
-            it.message shouldBe "Cannot read test/resource/does-not-exist.txt"
+            it.message shouldBe "File 'test/resource/does-not-exist.txt' doesn't exist"
         }
     }
 

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
@@ -44,6 +44,8 @@ class CommonTestResourcesAccessTest : FunSpec({
 
     test("CommonTestResourcesFileSystem - source(...) if file exists and can be read") {
         val source = CommonTestResourcesFileSystem.source("test/resource/foo.txt".toPath())
+
+        // Normalize new line endings to account for Windows.
         source.buffer().readUtf8().lines().joinToString(separator = "\n") shouldBe """
             Hello from multiplatform resources!
             Foo bar baz

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
@@ -61,6 +61,14 @@ class CommonTestResourcesAccessTest : FunSpec({
         }
     }
 
+    test("CommonTestResourcesFileSystem - source(...) if path points to directory") {
+        shouldThrow<IOException> {
+            CommonTestResourcesFileSystem.source("test/resource".toPath())
+        }.also {
+            it.message shouldBe "'test/resource' is not a file"
+        }
+    }
+
     test("CommonTestResourcesFileSystem - metadataOrNull(...) if file exists") {
         val metadata = CommonTestResourcesFileSystem.metadataOrNull("test/resource/foo.txt".toPath())
 

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/CommonTestResourcesAccessTest.kt
@@ -2,7 +2,12 @@ package it.krzeminski.snakeyaml.engine.kmp
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import okio.IOException
+import okio.Path.Companion.toPath
+import okio.buffer
 
 class CommonTestResourcesAccessTest : FunSpec({
     test("stringFromResources - resource exists") {
@@ -14,18 +19,18 @@ class CommonTestResourcesAccessTest : FunSpec({
     }
 
     test("stringFromResources - file doesn't exist") {
-        shouldThrow<IllegalArgumentException> {
+        shouldThrow<IOException> {
             stringFromResources("/test/resource/does-not-exist.txt")
         }.also {
-            it.message shouldBe "File 'does-not-exist.txt' doesn't exist in directory '/resources/test/resource/'!"
+            it.message shouldBe "Cannot read test/resource/does-not-exist.txt"
         }
     }
 
     test("stringFromResources - directory doesn't exist") {
-        shouldThrow<IllegalArgumentException> {
+        shouldThrow<IOException> {
             stringFromResources("/this/resource/for/sure/does/not/exist.txt")
         }.also {
-            it.message shouldBe "Directory 'this' doesn't exist in directory '/resources/'!"
+            it.message shouldBe "Cannot read this/resource/for/sure/does/not/exist.txt"
         }
     }
 
@@ -35,5 +40,71 @@ class CommonTestResourcesAccessTest : FunSpec({
         }.also {
             it.message shouldBe "A leading slash is required!"
         }
+    }
+
+    test("CommonTestResourcesFileSystem - source(...) if file exists and can be read") {
+        val source = CommonTestResourcesFileSystem.source("test/resource/foo.txt".toPath())
+        source.buffer().readUtf8() shouldBe """
+            Hello from multiplatform resources!
+            Foo bar baz
+
+        """.trimIndent()
+    }
+
+    test("CommonTestResourcesFileSystem - source(...) if file does not exist") {
+        shouldThrow<IOException> {
+            CommonTestResourcesFileSystem.source("test/resource/does-not-exist.txt".toPath())
+        }.also {
+            it.message shouldBe "Cannot read test/resource/does-not-exist.txt"
+        }
+    }
+
+    test("CommonTestResourcesFileSystem - metadataOrNull(...) if file exists") {
+        val metadata = CommonTestResourcesFileSystem.metadataOrNull("test/resource/foo.txt".toPath())
+
+        metadata.shouldNotBeNull()
+        metadata.isRegularFile shouldBe true
+        metadata.isDirectory shouldBe false
+    }
+
+    test("CommonTestResourcesFileSystem - metadataOrNull(...) if directory exists") {
+        val metadata = CommonTestResourcesFileSystem.metadataOrNull("test/resource".toPath())
+
+        metadata.shouldNotBeNull()
+        metadata.isDirectory shouldBe true
+        metadata.isRegularFile shouldBe false
+    }
+
+    test("CommonTestResourcesFileSystem - metadataOrNull(...) if file does not exist") {
+        val metadata = CommonTestResourcesFileSystem.metadataOrNull("test/resource/does-not-exist.txt".toPath())
+
+        metadata.shouldBeNull()
+    }
+
+    test("CommonTestResourcesFileSystem - list(...) if directory exists") {
+        val list = CommonTestResourcesFileSystem.list("test/resource".toPath())
+
+        list.map { it.name } shouldBe listOf("foo.txt")
+    }
+
+    test("CommonTestResourcesFileSystem - list(...) if directory does not exist") {
+        shouldThrow<IOException> {
+            CommonTestResourcesFileSystem.list("test/does-not-exist".toPath())
+        }.also {
+            it.message shouldBe "Cannot list test/does-not-exist"
+        }
+    }
+
+    test("CommonTestResourcesFileSystem - listOrNull(...) if directory exists") {
+        val list = CommonTestResourcesFileSystem.listOrNull("test/resource".toPath())
+
+        list.shouldNotBeNull()
+        list.map { it.name } shouldBe listOf("foo.txt")
+    }
+
+    test("CommonTestResourcesFileSystem - listOrNull(...) if directory does not exist") {
+        val list = CommonTestResourcesFileSystem.listOrNull("test/does-not-exist".toPath())
+
+        list.shouldBeNull()
     }
 })


### PR DESCRIPTION
Part of https://github.com/krzema12/snakeyaml-engine-kmp/issues/269.

It's a step towards using other common test resources. It focuses on implementing the custom Okio file system, and while we're doing it, we can reuse it for retrieving a single common test resource to avoid duplication.