### PR TITLE
Increase browserSocketTimeout parameter for karma tests

### DIFF
--- a/karma.config.d/karma.conf.js
+++ b/karma.config.d/karma.conf.js
@@ -4,6 +4,10 @@ module.exports = function(config) {
         // default timeout 60_000, but looks like it is not enough for macOS on GitHub runner
         // increasing the timeout should help to reduce number of failures
         captureTimeout: 120_000,
+        // the default value is 20_000
+        // according to the doc, the socket timeout can cause similar error as captureTimeout
+        // https://karma-runner.github.io/6.4/config/configuration-file.html#browsersockettimeout
+        browserSocketTimeout: 120_000,
     });
 };
 


### PR DESCRIPTION
There is one more parameter that can help reduce the chances of getting error:
> ChromeHeadless has not captured in 60000 ms, killing.

Related to #307 