### PR TITLE
Correct how config parameters for karma are set

### DIFF
--- a/karma.config.d/karma.conf.js
+++ b/karma.config.d/karma.conf.js
@@ -1,15 +1,13 @@
-module.exports = function(config) {
-    config.set({
-        // https://karma-runner.github.io/6.4/config/configuration-file.html#capturetimeout
-        // default timeout 60_000, but looks like it is not enough for macOS on GitHub runner
-        // increasing the timeout should help to reduce number of failures
-        captureTimeout: 120_000,
-        // the default value is 20_000
-        // according to the doc, the socket timeout can cause similar error as captureTimeout
-        // https://karma-runner.github.io/6.4/config/configuration-file.html#browsersockettimeout
-        browserSocketTimeout: 120_000,
-    });
-};
+config.set({
+    // https://karma-runner.github.io/6.4/config/configuration-file.html#capturetimeout
+    // default timeout 60_000, but looks like it is not enough for macOS on GitHub runner
+    // increasing the timeout should help to reduce number of failures
+    captureTimeout: 120_000,
+    // the default value is 20_000
+    // according to the doc, the socket timeout can cause similar error as captureTimeout
+    // https://karma-runner.github.io/6.4/config/configuration-file.html#browsersockettimeout
+    browserSocketTimeout: 120_000,
+});
 
 // A workaround from https://android-review.googlesource.com/c/platform/frameworks/support/+/3413540
 (function() {


### PR DESCRIPTION
Last time we had an error during test execution on macOS we saw that the **captureTimeout** parameter was not applied. This happened because the content of `karma.config.d/karma.conf.js` file was merged into the following block:

```js
module.exports = function(config) {
 // kotlin configuration
 // ...
 // content from our file
}
```

As a result, it looked like this:

```js
module.exports = function(config) {
 // kotlin configuration
 // ...
 // content from our file
 module.exports = function(config) {
 }
}
```

That was the reason, why our configuration changes were not applied. Let's see what happens with #307 issue after we correct the `karma.conf.js`