### PR TITLE
Allow reusing common test resources code generation

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/multiplatform-test-resources.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/multiplatform-test-resources.gradle.kts
@@ -17,4 +17,5 @@ val convertCommonTestResourcesToKotlin by tasks.registering(buildsrc.tasks.Conve
     // source sets instead of the required 'commonTest'.
     commonResourcesDir.set(project.projectDir.resolve("src").resolve("commonTest").resolve("resources"))
     destination.set(layout.buildDirectory.dir("generated-code-for-resources/src/commonTest/kotlin"))
+    accessorFileAndClassName.set("CommonTestResources")
 }

--- a/buildSrc/src/main/kotlin/buildsrc/tasks/ConvertCommonTestResourcesToKotlin.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/tasks/ConvertCommonTestResourcesToKotlin.kt
@@ -3,6 +3,7 @@ package buildsrc.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import java.nio.file.Path
@@ -26,6 +27,9 @@ abstract class ConvertCommonTestResourcesToKotlin @Inject constructor(
     @get:OutputDirectory
     abstract val destination: DirectoryProperty
 
+    @get:Input
+    abstract val accessorFileAndClassName: Property<String>
+
     @TaskAction
     fun action() {
         val destination = destination.asFile.get()
@@ -35,7 +39,7 @@ abstract class ConvertCommonTestResourcesToKotlin @Inject constructor(
         val resourcesMap = buildResourcesMap()
         val code = generateKotlinCode(resourcesMap)
 
-        destination.resolve("CommonTestResources.kt").writeText(code)
+        destination.resolve("${accessorFileAndClassName.get()}.kt").writeText(code)
     }
 
     private fun buildResourcesMap(): Map<String, Any> {
@@ -65,7 +69,7 @@ abstract class ConvertCommonTestResourcesToKotlin @Inject constructor(
         return """
             import okio.ByteString
 
-            object CommonTestResources {
+            object ${accessorFileAndClassName.get()} {
                 val resourcesMap: Map<String, Any> = ${getFunctionName("")}()
 
                 $stringBuilder


### PR DESCRIPTION
The goal is to allow accessing resources not only from `commonTest/resources`, but also from an arbitrary directory known during build time. In particular, we already generate code for the YAML comprehensive test suite ([buildSrc/src/main/kotlin/buildsrc/tasks/GenerateYamlTestSuiteData.kt](https://github.com/krzema12/snakeyaml-engine-kmp/blob/main/buildSrc/src/main/kotlin/buildsrc/tasks/GenerateYamlTestSuiteData.kt)), and we can replace it with the new code generation approach being adjusted in this PR. Thanks to this change, we'll be able to expose the YAML test data as a separate Okio file system, conveniently traversable in the tests.

This PR is just a piece of refactoring allowing it. Migrating the YAML test suite to use this approach will be done in a separate PR, to make things easier to review.