### PR TITLE
Fix StringStreamDataWriter.toString to not consume buffer

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/StringStreamDataWriter.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/StringStreamDataWriter.kt
@@ -16,5 +16,8 @@ internal class StringStreamDataWriter(
         buffer.writeUtf8(string = str, beginIndex = off, endIndex = off + len)
     }
 
-    override fun toString(): String = buffer.readUtf8()
+    /**
+     * Returns the contents of the internal buffer, without altering the buffer's state.
+     */
+    override fun toString(): String = buffer.peek().readUtf8()
 }

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/StringStreamDataWriterTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/StringStreamDataWriterTest.kt
@@ -1,0 +1,19 @@
+package it.krzeminski.snakeyaml.engine.kmp.api
+
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+
+class StringStreamDataWriterTest: FunSpec({
+    test("toString() doesn't consume buffer") {
+        val writer = StringStreamDataWriter()
+        writer.write("foobar")
+
+        // First read.
+        writer.toString()
+
+        withClue("subsequent calls to toString() shouldn't change the buffer's state") {
+            writer.toString() shouldContain "foobar"
+        }
+    }
+})


### PR DESCRIPTION
During debugging, it was confusing to see some contents of the buffer when pausing in the debugger before an assertion, but then seeing the assertion fail. It didn't make sense why the assertion fails - the value of the buffer was as expected.

It turned out that the debugger called `toString()`, consuming the buffer, and leaving an empty buffer when performing the assertion. The solution here is to just `peek()` the buffer in `toString()`, not consume it.