### PR TITLE
Synchronize kotest version to 6.0.0.M1 via version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,9 +37,9 @@ kotlin {
             )
 
             dependencies {
-                implementation("io.kotest:kotest-framework-engine:6.0.0.M1")
-                implementation("io.kotest:kotest-framework-api:6.0.0.M1")
-                implementation("io.kotest:kotest-assertions-core:6.0.0.M1")
+                implementation(libs.kotest.framework.engine)
+                implementation(libs.kotest.framework.api)
+                implementation(libs.kotest.assertions.core)
                 implementation("org.jetbrains:annotations:26.0.2")
                 // Overridig coroutines' version to solve a problem with WASM JS tests.
                 // See https://kotlinlang.slack.com/archives/CDFP59223/p1736191408326039?thread_ts=1734964013.996149&cid=CDFP59223
@@ -51,7 +51,7 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation("org.junit.jupiter:junit-jupiter-engine:5.11.4")
-                implementation("io.kotest:kotest-runner-junit5:6.0.0.M2")
+                implementation(libs.kotest.runner.junit5)
                 implementation("com.google.guava:guava:33.4.0-jre")
             }
         }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     //region Gradle Plugins
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.10")
-    implementation("io.kotest:kotest-framework-multiplatform-plugin-gradle:6.0.0.M2")
+    implementation(libs.kotest.framework.multiplatform.plugin.gradle)
     //endregion
 
     implementation("org.jetbrains:annotations:26.0.2")

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -13,4 +13,9 @@ dependencyResolutionManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+kotest = "6.0.0.M1"
+
+[libraries]
+kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
+kotest-framework-api = { module = "io.kotest:kotest-framework-api", version.ref = "kotest" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-framework-multiplatform-plugin-gradle = { module = "io.kotest:kotest-framework-multiplatform-plugin-gradle", version.ref = "kotest" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }


### PR DESCRIPTION
I see that Renovate managed to bump two packages, and for other packages, CI is failing. Not sure if it's because the artifacts are broken, or the changes need to go together. To solve it, let's make Renovate bump versions of all kotest-related packages at once, for the sake of consistency.

This change downgrades some kotest-related libraries to 6.0.0.M1.