### PR TITLE
Fix CoreScalarResolver.INT regex to work with JS

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/resolver/CoreScalarResolver.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/resolver/CoreScalarResolver.kt
@@ -51,9 +51,9 @@ class CoreScalarResolver : BaseScalarResolver(
         /** Integer as defined in Core */
         @JvmField
         val INT = Regex(
-            "^([-+]?[0-9]+)" + // (base 10)
+            "^(([-+]?[0-9]+)" + // (base 10)
                     "|(0o[0-7]+)" + // (base 8)
-                    "|(0x[0-9a-fA-F]+)$", // (base 16)
+                    "|(0x[0-9a-fA-F]+))$", // (base 16)
         )
 
         /** Null as defined in Core */


### PR DESCRIPTION
Found when converting the corresponding test to KMP: https://github.com/krzema12/snakeyaml-engine-kmp/pull/397

What helped me here is this tool that renders the regex as a graph: https://www.debuggex.com/

Before the fix - I noticed that `^` and `$` are attached to the groups nearest to them:
<img width="306" alt="Screenshot 2025-02-06 at 09 05 30" src="https://github.com/user-attachments/assets/c3e2c00f-456f-4e5b-b3ff-820651eefd7b" />

After the fix - creating a new group that contains the rest fixes the problem:
<img width="347" alt="Screenshot 2025-02-06 at 09 06 08" src="https://github.com/user-attachments/assets/2195e571-574a-468a-bf0c-b83cadc64c62" />