### PR TITLE
Remove dependency on kotest-framework-api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,6 @@ kotlin {
 
             dependencies {
                 implementation(libs.kotest.framework.engine)
-                implementation(libs.kotest.framework.api)
                 implementation(libs.kotest.assertions.core)
                 implementation("org.jetbrains:annotations:26.0.2")
                 // Overridig coroutines' version to solve a problem with WASM JS tests.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ kotest = "6.0.0.M1"
 
 [libraries]
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
-kotest-framework-api = { module = "io.kotest:kotest-framework-api", version.ref = "kotest" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-framework-multiplatform-plugin-gradle = { module = "io.kotest:kotest-framework-multiplatform-plugin-gradle", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }


### PR DESCRIPTION
Looks like we don't use it anywhere, and kotest 6.0.0.M2 doesn't have this artifact (see https://github.com/kotest/kotest/pull/4590).
This change is needed to update to 6.0.0.M2: https://github.com/krzema12/snakeyaml-engine-kmp/pull/400.