### PR TITLE
Fix publishing for native targets

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/base.gradle.kts
@@ -20,13 +20,6 @@ tasks.withType<AbstractArchiveTask>().configureEach {
     isReproducibleFileOrder = true
 }
 
-
-tasks.withType<AbstractCopyTask>().configureEach {
-    // When copy/sync tasks move or exclude files Gradle will retain redundant directories, even if
-    // they're empty. This is usually useless, so by default tell Gradle to remove empty dirs.
-    includeEmptyDirs = false
-}
-
 tasks.withType<Test>().configureEach {
     testLogging {
         events(


### PR DESCRIPTION
Part of https://github.com/krzema12/snakeyaml-engine-kmp/issues/405.

Judging by the comment, this piece of config is probably for the sake of keeping the directory tree clean, and not to implement certain behavior. This piece also breaks publishing of KLibs in Kotlin 2.1.0, because of reasons described in https://youtrack.jetbrains.com/issue/KT-74871/KN-NoSuchFileException-default-targets-linuxx64-kotlin-with-snakeyaml-engine-kmp-3.1.0#focus=Comments-27-11510364.0-0.