### PR TITLE
Move all dependencies to Gradle version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,8 +8,8 @@ plugins {
     buildsrc.conventions.publishing
     buildsrc.conventions.`yaml-testing`
     buildsrc.conventions.`multiplatform-test-resources`
-    id("dev.adamko.dokkatoo-html") version "2.4.0"
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.18.1"
+    alias(libs.plugins.dokkatoo.html)
+    alias(libs.plugins.kotlinx.binary.compatibility.validator)
 }
 
 group = "it.krzeminski"
@@ -24,8 +24,8 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("com.squareup.okio:okio:3.15.0")
-                implementation("net.thauvin.erik.urlencoder:urlencoder-lib:1.6.0")
+                implementation(libs.okio)
+                implementation(libs.urlencoder.lib)
             }
         }
 
@@ -38,7 +38,7 @@ kotlin {
             dependencies {
                 implementation(libs.kotest.framework.engine)
                 implementation(libs.kotest.assertions.core)
-                implementation("org.jetbrains:annotations:26.0.2")
+                implementation(libs.jetbrains.annotations)
                 // Overridig coroutines' version to solve a problem with WASM JS tests.
                 // See https://kotlinlang.slack.com/archives/CDFP59223/p1736191408326039?thread_ts=1734964013.996149&cid=CDFP59223
                 // TODO: remove this workaround in https://github.com/krzema12/snakeyaml-engine-kmp/issues/337
@@ -48,9 +48,9 @@ kotlin {
 
         jvmTest {
             dependencies {
-                implementation("org.junit.jupiter:junit-jupiter-engine:5.13.4")
+                implementation(libs.junit.jupiter.engine)
                 implementation(libs.kotest.runner.junit5)
-                implementation("com.google.guava:guava:33.4.8-jre")
+                implementation(libs.guava)
             }
         }
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,12 +4,12 @@ plugins {
 
 dependencies {
     //region Gradle Plugins
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21")
+    implementation(libs.kotlin.gradle.plugin)
     implementation(libs.kotest.framework.multiplatform.plugin.gradle)
     implementation(libs.maven.publish.gradle.plugin)
     //endregion
 
-    implementation("org.jetbrains:annotations:26.0.2")
+    implementation(libs.jetbrains.annotations)
 
-    implementation("io.github.java-diff-utils:java-diff-utils:4.16")
+    implementation(libs.java.diff.utils)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,36 @@
 [versions]
+kotlin = "2.1.21"
 kotest = "6.0.0.M1"
+okio = "3.15.0"
+urlencoder-lib = "1.6.0"
+kotlinx-benchmark = "0.4.14"
+snakeyaml-engine = "2.10"
+dokkatoo = "2.4.0"
+kotlinx-binary-compatibility-validator = "0.18.1"
+jetbrains-annotations = "26.0.2"
+junit-jupiter = "5.13.4"
+guava = "33.4.8-jre"
+java-diff-utils = "4.16"
 
 [libraries]
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-framework-multiplatform-plugin-gradle = { module = "io.kotest:kotest-framework-multiplatform-plugin-gradle", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+okio-nodefilesystem = { module = "com.squareup.okio:okio-nodefilesystem", version.ref = "okio" }
+urlencoder-lib = { module = "net.thauvin.erik.urlencoder:urlencoder-lib", version.ref = "urlencoder-lib" }
+snakeyaml-engine = { module = "org.snakeyaml:snakeyaml-engine", version.ref = "snakeyaml-engine" }
+kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
 maven-publish-gradle-plugin = { module = "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin", version = "0.34.0"}
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+java-diff-utils = { module = "io.github.java-diff-utils:java-diff-utils", version.ref = "java-diff-utils" }
+
+[plugins]
+kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
+kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
+dokkatoo-html = { id = "dev.adamko.dokkatoo-html", version.ref = "dokkatoo" }
+kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binary-compatibility-validator" }

--- a/snake-kmp-benchmarks/build.gradle.kts
+++ b/snake-kmp-benchmarks/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("multiplatform")
-    kotlin("plugin.allopen") version "2.1.21"
-    id("org.jetbrains.kotlinx.benchmark") version "0.4.14"
+    alias(libs.plugins.kotlin.allopen)
+    alias(libs.plugins.kotlinx.benchmark)
 }
 
 allOpen {
@@ -50,24 +50,23 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(projects.snakeyamlEngineKmp)
-                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.14")
-                implementation(project.dependencies.platform("com.squareup.okio:okio-bom:3.15.0"))
-                implementation("com.squareup.okio:okio")
+                implementation(libs.kotlinx.benchmark.runtime)
+                implementation(libs.okio)
             }
         }
 
         jvmMain {
             dependencies {
-                implementation("org.snakeyaml:snakeyaml-engine:2.10")
+                implementation(libs.snakeyaml.engine)
             }
         }
 
         jsMain {
             dependencies {
-                implementation("net.thauvin.erik.urlencoder:urlencoder-lib:1.6.0") {
-                    because("benchmark compilation requires explicit dependencies for JS targets - https://github.com/Kotlin/kotlinx-benchmark/issues/185")
-                }
-                implementation("com.squareup.okio:okio-nodefilesystem")
+                // Needed because benchmark compilation requires explicit dependencies for JS targets
+                // - https://github.com/Kotlin/kotlinx-benchmark/issues/185"
+                implementation(libs.urlencoder.lib)
+                implementation(libs.okio.nodefilesystem)
             }
         }
     }


### PR DESCRIPTION
For the sake of easier management of versions, and to make automatic version bumps easier.