### PR TITLE
Remove explicit dependency on urlencoder-lib in benchmark project

### DIFF
--- a/snake-kmp-benchmarks/build.gradle.kts
+++ b/snake-kmp-benchmarks/build.gradle.kts
@@ -63,9 +63,6 @@ kotlin {
 
         jsMain {
             dependencies {
-                // Needed because benchmark compilation requires explicit dependencies for JS targets
-                // - https://github.com/Kotlin/kotlinx-benchmark/issues/185"
-                implementation(libs.urlencoder.lib)
                 implementation(libs.okio.nodefilesystem)
             }
         }


### PR DESCRIPTION
Thanks to https://github.com/Kotlin/kotlinx-benchmark/pull/292, we don't have to specify this transitive dependency anymore.