### PR TITLE
Set minimum JDK version to 11

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
@@ -114,7 +114,7 @@ kotlin {
 }
 
 //region Java versioning
-val minSupportedJavaVersion = JavaVersion.VERSION_1_8
+val minSupportedJavaVersion = JavaVersion.VERSION_11
 
 // use Java 21 to compile the project
 val javaCompiler = javaToolchains.compilerFor(21)


### PR DESCRIPTION
Last year we enabled support for JDK 8: https://github.com/krzema12/snakeyaml-engine-kmp/issues/202.

However:
* (the driver of this PR) the newest kotest supports JDK 11+ (https://github.com/kotest/kotest/blob/569fb2bfe1427d0d8879003f420ea3aff50c2793/documentation/docs/release_6.0.md?plain=1#L95)
* kaml targets JDK11 (https://github.com/charleskorn/kaml/blob/81a5c797057608fb0785d22c1ce29143fd3af9be/build.gradle.kts#L111, https://github.com/charleskorn/kaml/blob/81a5c797057608fb0785d22c1ce29143fd3af9be/build.gradle.kts#L132)
* version 11 has been EOL for over 3 years (https://endoflife.date/oracle-jdk)
* TODO: check if the motivation related to Bukkit (https://github.com/krzema12/snakeyaml-engine-kmp/issues/202) supporting Java 8 still holds