### PR TITLE
Remove unused vals with Java versions

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     ExperimentalWasmDsl::class,
 )
 kotlin {
+    // Use modern JDK to build the project.
     jvmToolchain(21)
 
     //region JVM Targets
@@ -115,11 +116,6 @@ kotlin {
 
 //region Java versioning
 val minSupportedJavaVersion = JavaVersion.VERSION_1_8
-
-// use Java 21 to compile the project
-val javaCompiler = javaToolchains.compilerFor(21)
-// use minimum Java version to run the tests
-val javaTestLauncher = javaToolchains.launcherFor(minSupportedJavaVersion)
 
 kotlin.targets.withType<KotlinJvmTarget>().configureEach {
     @OptIn(ExperimentalKotlinGradlePluginApi::class)


### PR DESCRIPTION
These are unused and were never used (were added in https://github.com/krzema12/snakeyaml-engine-kmp/pull/255 already as unused).

Details:
* `javaCompiler` - this version is in fact defined here: https://github.com/krzema12/snakeyaml-engine-kmp/blob/13a7d519148133cc2f9df7a0db72de2d774e68b0/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts#L31
* `javaTestLauncher` was probably intended to be used here: https://github.com/krzema12/snakeyaml-engine-kmp/blob/13a7d519148133cc2f9df7a0db72de2d774e68b0/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts#L136