### PR TITLE
Change separator for YAML test suite test IDs

### DIFF
--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/SuiteUtils.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/SuiteUtils.kt
@@ -154,7 +154,9 @@ internal object SuiteUtils {
 
     private fun Set<String>.mapToYamlTestDataId(): Set<YamlTestData.Id> =
         map { id ->
-            val updatedId = id.replace("-", ":")
+            val updatedId = id
+                .replace("-", "_")
+                .replace(":", "_")
             YamlTestData.Id(updatedId)
         }.toSet()
 }

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/YamlTestData.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/YamlTestData.kt
@@ -38,7 +38,7 @@ internal val YamlTestSuiteData: Map<YamlTestData.Id, YamlTestData> =
     YamlTestResourcesFileSystem.fsPath("/").listRecursively()
         .filter { it.isDirectory && (it / "===").exists }
         .associate { dir ->
-            val id = YamlTestData.Id(dir.path.segments.joinToString(":"))
+            val id = YamlTestData.Id(dir.path.segments.joinToString("_"))
             id to generateYamlTestDataObject(id, dir)
         }
 


### PR DESCRIPTION
This is a prerequisite to upgrade to Gradle 9. There's a problem on Windows with the colon (`:`) in the paths, so let's not use it.