### PR TITLE
Remove usage of Gradle toolchain

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
@@ -27,9 +27,6 @@ plugins {
     ExperimentalWasmDsl::class,
 )
 kotlin {
-    // Use modern JDK to build the project.
-    jvmToolchain(21)
-
     //region JVM Targets
     jvm()
     //endregion


### PR DESCRIPTION
Let's use the JDK that is available on the host. Thanks to requiring specific JDK for Kotlin and Java compilation, Gradle will fail if no sufficiently new JDK is available.