### PR TITLE
[Port from snakeyaml-engine] Fix parsing comments inside flow mapping context

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/parser/ParserImpl.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/parser/ParserImpl.kt
@@ -857,10 +857,18 @@ class ParserImpl(
         private val first: Boolean,
     ) : Production {
         override fun produce(): Event {
+            if (scanner.checkToken(Token.ID.Comment)) {
+                state = ParseFlowMappingKey(first)
+                return produceCommentEvent((scanner.next() as CommentToken))
+            }
             if (!scanner.checkToken(Token.ID.FlowMappingEnd)) {
                 if (!first) {
                     if (scanner.checkToken(Token.ID.FlowEntry)) {
                         scanner.next()
+                        if (scanner.checkToken(Token.ID.Comment)) {
+                            state = ParseFlowMappingKey(true)
+                            return produceCommentEvent((scanner.next() as CommentToken))
+                        }
                     } else {
                         val token = scanner.peekToken()
                         throw ParserException(

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/comments/DumpCommentInFlowStyleTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/comments/DumpCommentInFlowStyleTest.kt
@@ -1,6 +1,5 @@
 package it.krzeminski.snakeyaml.engine.kmp.comments
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
@@ -10,7 +9,6 @@ import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.api.lowlevel.Compose
 import it.krzeminski.snakeyaml.engine.kmp.api.lowlevel.Present
 import it.krzeminski.snakeyaml.engine.kmp.api.lowlevel.Serialize
-import it.krzeminski.snakeyaml.engine.kmp.exceptions.ParserException
 import it.krzeminski.snakeyaml.engine.kmp.nodes.MappingNode
 import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
 
@@ -31,15 +29,12 @@ class DumpCommentInFlowStyleTest : FunSpec({
     test("flow with comments") {
         val loader = Compose(LoadSettings.builder().setParseComments(true).build())
         val content = "{ url: text # comment breaks it\n}"
-        shouldThrow<ParserException> {
-            loader.compose(content)!!
-        }
+        val node = loader.compose(content)!!
+        extractInlineComment(node) shouldBe " comment breaks it"
 
-        // TODO: uncomment likely in https://github.com/krzema12/snakeyaml-engine-kmp/issues/451
-        //  where the test should start passing
-//        val serialize = Serialize(DumpSettings.builder().setDumpComments(true).build())
-//        val events = serialize.serializeOne(node)
-//        events.shouldHaveSize(8)
+        val serialize = Serialize(DumpSettings.builder().setDumpComments(true).build())
+        val events = serialize.serializeOne(node)
+        events.shouldHaveSize(9)
     }
 
     test("block with comments") {


### PR DESCRIPTION
Fixes https://github.com/krzema12/snakeyaml-engine-kmp/issues/451.

Ports https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/155a7a9fe0c7d356194f11400ddfc3acf19922a1.