### PR TITLE
[Port from snakeyaml-engine] Add tests for dividing strings with spaces

### DIFF
--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue47/SetWidthTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue47/SetWidthTest.kt
@@ -14,7 +14,7 @@ import it.krzeminski.snakeyaml.engine.kmp.events.*
 class SetWidthTest : FunSpec({
     val stringToSerialize = "arn:aws:iam::12345678901234567890:foobarbaz:testing:testing2:role/github-actions-role/\${{ github.token }}"
 
-    test("emit plain string and split") {
+    test("emitted plain text via Dump with limited width should be split") {
         val settings = DumpSettings.builder().setWidth(80).build() // Intentionally limited.
         val writer = StringStreamDataWriter()
         val dump = Dump(settings)
@@ -25,7 +25,7 @@ class SetWidthTest : FunSpec({
         yaml.trim() shouldBe expected
     }
 
-    test("emit plain and split") {
+    test("emitted plain text via Emitter with limited width should be split") {
         val settings = DumpSettings.builder().setWidth(80).build() // Intentionally limited.
         val writer = StringStreamDataWriter()
         with(Emitter(settings, writer)) {
@@ -40,7 +40,7 @@ class SetWidthTest : FunSpec({
         yaml shouldBe expected
     }
 
-    test("emit plain and no split") {
+    test("emitted plain text via Emitter with width longer than emitted text should not be split") {
         val settings = DumpSettings.builder().setWidth(180).build() // Intentionally limited.
         val writer = StringStreamDataWriter()
         with(Emitter(settings, writer)) {
@@ -56,7 +56,7 @@ class SetWidthTest : FunSpec({
         parseBack(yaml) shouldBe stringToSerialize
     }
 
-    test("emit folded") {
+    test("emitted plain text with limited width and folded scalar style should be split") {
         val settings = DumpSettings.builder()
             .setWidth(80) // Intentionally limited.
             .setDefaultScalarStyle(ScalarStyle.FOLDED)

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue47/SetWidthTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue47/SetWidthTest.kt
@@ -30,9 +30,15 @@ class SetWidthTest : FunSpec({
         val writer = StringStreamDataWriter()
         with(Emitter(settings, writer)) {
             emit(StreamStartEvent())
-            emit(DocumentStartEvent(false, null, emptyMap()))
-            emit(ScalarEvent(null, null, ImplicitTuple(true, true), stringToSerialize, ScalarStyle.PLAIN))
-            emit(DocumentEndEvent(false))
+            emit(DocumentStartEvent(explicit = false, specVersion = null, tags = emptyMap()))
+            emit(ScalarEvent(
+                anchor = null,
+                tag = null,
+                implicit = ImplicitTuple(plain = true, nonPlain = true),
+                value = stringToSerialize,
+                scalarStyle = ScalarStyle.PLAIN,
+            ))
+            emit(DocumentEndEvent(isExplicit = false))
             emit(StreamEndEvent())
         }
         val yaml = writer.toString()
@@ -45,9 +51,15 @@ class SetWidthTest : FunSpec({
         val writer = StringStreamDataWriter()
         with(Emitter(settings, writer)) {
             emit(StreamStartEvent())
-            emit(DocumentStartEvent(false, null, emptyMap()))
-            emit(ScalarEvent(null, null, ImplicitTuple(true, true), stringToSerialize, ScalarStyle.PLAIN))
-            emit(DocumentEndEvent(false))
+            emit(DocumentStartEvent(explicit = false, specVersion = null, tags = emptyMap()))
+            emit(ScalarEvent(
+                anchor = null,
+                tag = null,
+                implicit = ImplicitTuple(plain = true, nonPlain = true),
+                value = stringToSerialize,
+                scalarStyle = ScalarStyle.PLAIN,
+            ))
+            emit(DocumentEndEvent(isExplicit = false))
             emit(StreamEndEvent())
         }
         val yaml = writer.toString()

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue47/SetWidthTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue47/SetWidthTest.kt
@@ -1,0 +1,78 @@
+package it.krzeminski.snakeyaml.engine.kmp.issues.issue47
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import it.krzeminski.snakeyaml.engine.kmp.api.Dump
+import it.krzeminski.snakeyaml.engine.kmp.api.DumpSettings
+import it.krzeminski.snakeyaml.engine.kmp.api.Load
+import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
+import it.krzeminski.snakeyaml.engine.kmp.api.StringStreamDataWriter
+import it.krzeminski.snakeyaml.engine.kmp.common.ScalarStyle
+import it.krzeminski.snakeyaml.engine.kmp.emitter.Emitter
+import it.krzeminski.snakeyaml.engine.kmp.events.*
+
+class SetWidthTest : FunSpec({
+    val stringToSerialize = "arn:aws:iam::12345678901234567890:foobarbaz:testing:testing2:role/github-actions-role/\${{ github.token }}"
+
+    test("emit plain string and split") {
+        val settings = DumpSettings.builder().setWidth(80).build() // Intentionally limited.
+        val writer = StringStreamDataWriter()
+        val dump = Dump(settings)
+        dump.dump(stringToSerialize, writer)
+        val yaml = writer.toString()
+        val expected = "arn:aws:iam::12345678901234567890:foobarbaz:testing:testing2:role/github-actions-role/\${{\n  github.token }}"
+        parseBack(yaml) shouldBe stringToSerialize
+        yaml.trim() shouldBe expected
+    }
+
+    test("emit plain and split") {
+        val settings = DumpSettings.builder().setWidth(80).build() // Intentionally limited.
+        val writer = StringStreamDataWriter()
+        with(Emitter(settings, writer)) {
+            emit(StreamStartEvent())
+            emit(DocumentStartEvent(false, null, emptyMap()))
+            emit(ScalarEvent(null, null, ImplicitTuple(true, true), stringToSerialize, ScalarStyle.PLAIN))
+            emit(DocumentEndEvent(false))
+            emit(StreamEndEvent())
+        }
+        val yaml = writer.toString()
+        val expected = "arn:aws:iam::12345678901234567890:foobarbaz:testing:testing2:role/github-actions-role/\${{\n  github.token }}\n"
+        yaml shouldBe expected
+    }
+
+    test("emit plain and no split") {
+        val settings = DumpSettings.builder().setWidth(180).build() // Intentionally limited.
+        val writer = StringStreamDataWriter()
+        with(Emitter(settings, writer)) {
+            emit(StreamStartEvent())
+            emit(DocumentStartEvent(false, null, emptyMap()))
+            emit(ScalarEvent(null, null, ImplicitTuple(true, true), stringToSerialize, ScalarStyle.PLAIN))
+            emit(DocumentEndEvent(false))
+            emit(StreamEndEvent())
+        }
+        val yaml = writer.toString()
+        val expected = "arn:aws:iam::12345678901234567890:foobarbaz:testing:testing2:role/github-actions-role/\${{ github.token }}\n"
+        yaml shouldBe expected
+        parseBack(yaml) shouldBe stringToSerialize
+    }
+
+    test("emit folded") {
+        val settings = DumpSettings.builder()
+            .setWidth(80) // Intentionally limited.
+            .setDefaultScalarStyle(ScalarStyle.FOLDED)
+            .build()
+        val dump = Dump(settings)
+        val yaml = dump.dumpToString(stringToSerialize)
+        val expected = ">-\n" +
+            "  arn:aws:iam::12345678901234567890:foobarbaz:testing:testing2:role/github-actions-role/\${{\n" +
+            "  github.token }}\n"
+        yaml shouldBe expected
+        parseBack(yaml) shouldBe stringToSerialize
+    }
+})
+
+private fun parseBack(yaml: String): String {
+    val settings = LoadSettings.builder().build()
+    val load = Load(settings)
+    return load.loadOne(yaml).toString()
+}


### PR DESCRIPTION
Fixes https://github.com/krzema12/snakeyaml-engine-kmp/issues/506.

Ports multiple changes since individual commits make changes that make the tests fail, only the last commit makes the tests pass:
 * https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/7eea790d14c986276f0095dd87694d5510cb34fd
 * https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/061a977e9830bbd300e3a3c0cddf553a2ff4275c
 * https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/9dfb6b6a1a45f4802f4ae3de5b22353cdc101724
 * https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/e55f1a6957d5f422f62dd61260ca68a2ac9a01a8