### PR TITLE
Revert updating to Gradle 9

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/yaml-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/yaml-testing.gradle.kts
@@ -1,6 +1,6 @@
 package buildsrc.conventions
 
-import buildsrc.conventions.Constants.YAML_TEST_TASK_GROUP
+import buildsrc.conventions.Yaml_testing_gradle.Constants.YAML_TEST_TASK_GROUP
 import buildsrc.utils.asConsumer
 import buildsrc.utils.dropDirectories
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR reverts https://github.com/krzema12/snakeyaml-engine-kmp/pull/484.

It's needed because kotest 6.0.0 doesn't support Gradle 9 yet (https://github.com/kotest/kotest/issues/5019), and it's better to use kotest 6.0.0 to be able to use Kotlin 2.2.0+, and wait for Gradle 9.