### PR TITLE
On MacOS in CI, just run tests for MacOS/iOS targets

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -58,9 +58,13 @@ workflow(
                     gradleVersion = "wrapper",
                 ),
             )
+            val target = when (jobRunner) {
+                MacOSLatest -> "macOsAllTest"
+                else -> "build"
+            }
             run(
-                name = "Build",
-                command = "./gradlew build --stacktrace",
+                name = "Build/test",
+                command = "./gradlew $target --stacktrace",
             )
         }
     }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
       with:
         gradle-version: 'wrapper'
     - id: 'step-4'
-      name: 'Build'
+      name: 'Build/test'
       run: './gradlew build --stacktrace'
   build-on-MacOSLatest:
     runs-on: 'macos-latest'
@@ -77,8 +77,8 @@ jobs:
       with:
         gradle-version: 'wrapper'
     - id: 'step-4'
-      name: 'Build'
-      run: './gradlew build --stacktrace'
+      name: 'Build/test'
+      run: './gradlew macOsAllTest --stacktrace'
   build-on-WindowsLatest:
     runs-on: 'windows-latest'
     needs:
@@ -104,7 +104,7 @@ jobs:
       with:
         gradle-version: 'wrapper'
     - id: 'step-4'
-      name: 'Build'
+      name: 'Build/test'
       run: './gradlew build --stacktrace'
   build_kotlin_scripts:
     name: 'Build Kotlin scripts'

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
@@ -4,6 +4,7 @@ import buildsrc.utils.JavaLanguageVersion
 import buildsrc.utils.JvmTarget
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
@@ -165,5 +166,20 @@ afterEvaluate {
 
         // produce an error if there's no lock file
         reportNewYarnLock = true
+    }
+}
+
+val macOsAllTest by tasks.register("macOsAllTest") {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = "Runs all tests for MacOs and iOS targets"
+}
+
+kotlin.targets.configureEach {
+    if (this !is KotlinTargetWithTests<*, *>) {
+        return@configureEach
+    }
+
+    if (setOf("macos", "ios").any { name.startsWith(it) }) {
+        macOsAllTest.dependsOn(tasks.named("${name}Test"))
     }
 }


### PR DESCRIPTION
The immediate reason for this change is not being able to update to kotest 6.0.0 and Kotlin 2.2.0.
See e.g. https://github.com/krzema12/snakeyaml-engine-kmp/actions/runs/17149519010/job/48656766305:

```
java.lang.IllegalStateException: Errors occurred during launch of browser for testing.
> Task :jsBrowserTest
- ChromeHeadless
Please make sure that you have installed browsers.
Or change it via
browser {
    testTask {
        useKarma {
            useFirefox()
            useChrome()
            useSafari()
        }
    }
}
```

It's weird because there's Chrome in the runner image: https://github.com/actions/runner-images/blob/9943ce2a33e95ba38691c0b26d5079a3216718e1/images/macos/macos-15-arm64-Readme.md?plain=1#L92. In general, MacOS workers are pretty weak, and make the builds longer. This change leads to not running browser tests on MacOS, which should be fine since we run them on Linux and Windows - this coverage is enough.

For Linux and Windows runners, I'd like us to refrain for these changes for now, just to make a minimal change that fixes the current problems.

This change is inspired by https://github.com/OptimumCode/json-schema-validator/blob/6558910afd62b22ed65183db4c08e5cbebc3b8fa/buildSrc/src/main/kotlin/convention.multiplatform-tests.gradle.kts#L7.