### PR TITLE
Remove Maven version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Maven Central Version](https://maven-badges.herokuapp.com/maven-central/it.krzeminski/snakeyaml-engine-kmp/badge.svg)](https://maven-badges.herokuapp.com/maven-central/it.krzeminski/snakeyaml-engine-kmp)
-
 [![Commits to upstream](https://raw.githubusercontent.com/krzema12/snakeyaml-engine-kmp/refs/heads/commits-to-upstream-badge/commits-to-upstream-badge.svg)](https://raw.githubusercontent.com/krzema12/snakeyaml-engine-kmp/refs/heads/commits-to-upstream-badge/log-diff-between-repos.txt) - the number of commits in snakeyaml-engine to be considered as candidates for porting to snakeyaml-engine-kmp
 
 # SnakeYAML Engine KMP


### PR DESCRIPTION
It shows and links to an outdated version. The users can use the Releases view in GitHub to get the newest version.