### PR TITLE
Validate existence of YAML test case ID

### DIFF
--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/SuiteUtils.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/SuiteUtils.kt
@@ -49,7 +49,6 @@ internal object SuiteUtils {
         // should pass but fail
         "3RLN-01",
         "3RLN-04",
-        "4MUZ",
         "4MUZ-00",
         "4MUZ-01",
         "4MUZ-02",
@@ -73,7 +72,6 @@ internal object SuiteUtils {
         "K3WX",
         "K54U",
         "KH5V-01",
-        "KZN9",
         "M2N8-00",
         "M7A3",
         "MUS6-03",

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/TestSuiteTests.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/TestSuiteTests.kt
@@ -3,6 +3,7 @@ package it.krzeminski.snakeyaml.engine.kmp.test_suite
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeIn
 import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -98,6 +99,18 @@ class TestSuiteTests : FunSpec({
                         }
                 }
             }
+        }
+    }
+
+    deviationsInResult.forEach { id ->
+        test("validate deviation in result $id") {
+            id shouldBeIn YamlTestSuiteData.keys
+        }
+    }
+
+    deviationsInEvents.forEach { id ->
+        test("validate deviation in events $id") {
+            id shouldBeIn YamlTestSuiteData.keys
         }
     }
 })


### PR DESCRIPTION
Thanks to this change, we're sure that the IDs in `deviationsInResult` and `deviationsInEvents` correspond to existing test cases.

It turned out that the newly added tests found two items on the lists that were invalid, so removing them here.

Inspired by https://github.com/krzema12/snakeyaml-engine-kmp/issues/561.