### PR TITLE
[Port from snakeyaml-engine] Parse escaped TAB in double-quoted scalar

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ScannerImpl.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ScannerImpl.kt
@@ -1777,6 +1777,13 @@ class ScannerImpl(
                             contextMark = reader.getMark(),
                         )
                     }
+                } else if (c == '\t'.code) {
+                    // https://yaml.org/spec/1.2.2/#57-escaped-characters
+                    // This is useful at the start or the end of a line to force a leading or trailing tab to
+                    // become part of the content.
+                    // (this is confusing, because \t is more readable than \TAB)
+                    chunks.append('\t')
+                    reader.forward()
                 } else if (scanLineBreak() != null) {
                     chunks.append(scanFlowScalarBreaks(startMark))
                 } else {

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue69/TabInDoubleQuoteTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue69/TabInDoubleQuoteTest.kt
@@ -1,0 +1,18 @@
+package it.krzeminski.snakeyaml.engine.kmp.issues.issue69
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import it.krzeminski.snakeyaml.engine.kmp.api.Load
+import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
+
+class TabInDoubleQuoteTest : FunSpec({
+    test("tab in double quote") {
+        val options = LoadSettings.builder().setParseComments(true).build()
+        val load = Load(options)
+        val str = "- \"\\\t\"" // "\TAB"
+        val obj = load.loadOne(str) as List<String>
+        obj shouldHaveSize 1
+        obj[0] shouldBe "\t"
+    }
+})

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/Deviations.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/test_suite/Deviations.kt
@@ -25,8 +25,6 @@ val deviationsInResult: Set<TestIdWithLabel> = setOf(
     "Y79Y-003" meaning "Tabs in various contexts",
 
     // should pass but fail
-    "3RLN-01" meaning "Leading tabs in double quoted",
-    "3RLN-04" meaning "Leading tabs in double quoted",
     "4MUZ-00" meaning "Flow mapping colon on line after key",
     "4MUZ-01" meaning "Flow mapping colon on line after key",
     "4MUZ-02" meaning "Flow mapping colon on line after key",
@@ -39,8 +37,6 @@ val deviationsInResult: Set<TestIdWithLabel> = setOf(
     "A2M4" meaning "Spec Example 6.2. Indentation Indicators",
     "DBG4" meaning "Spec Example 7.10. Plain Characters",
     "DC7X" meaning "Various trailing tabs",
-    "DE56-02" meaning "Trailing tabs in double quoted",
-    "DE56-03" meaning "Trailing tabs in double quoted",
     "DK3J" meaning "Zero indented block scalar with line that looks like a comment",
     "FP8R" meaning "Zero indented block scalar",
     "FRK4" meaning "Spec Example 7.3. Completely Empty Flow Nodes",
@@ -49,7 +45,6 @@ val deviationsInResult: Set<TestIdWithLabel> = setOf(
     "J3BT" meaning "Spec Example 5.12. Tabs and Spaces",
     "K3WX" meaning "Colon and adjacent value after comment on next line",
     "K54U" meaning "Tab after document header",
-    "KH5V-01" meaning "Inline tabs in double quoted",
     "M2N8-00" meaning "Question mark edge cases",
     "M7A3" meaning "Spec Example 9.3. Bare Documents",
     "MUS6-03" meaning "Directive variants",


### PR DESCRIPTION
Fixes https://github.com/krzema12/snakeyaml-engine-kmp/issues/560.

Ports https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/5656f99119c07ed5be6bbf42e7a6f4eadb67a86d.