### PR TITLE
[Port from snakeyaml-engine] Fix misleading tests and improve docstrings

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadSettingsBuilder.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadSettingsBuilder.kt
@@ -227,8 +227,9 @@ class LoadSettingsBuilder internal constructor() {
     }
 
     /**
-     * The max amount of code points for every input YAML document in the stream. Please be aware that
-     * byte limit depends on the encoding.
+     * The max number of code points for every input YAML document in the stream. Please be aware that
+     * the byte limit depends on the encoding. The presence of the document indicators '---' or/and
+     * '...' will affect the doc size (even though they do not belong to the document content)
      *
      * @param codePointLimit - the max allowed size of a single YAML document in a stream
      * @return the builder with the provided value

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/parser/Parser.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/parser/Parser.kt
@@ -25,7 +25,7 @@ import it.krzeminski.snakeyaml.engine.kmp.events.Event
 interface Parser : Iterator<Event> {
 
     /**
-     * Check if the next event is one of the given type.
+     * Check if the next event is of the given type.
      *
      * @param choice Event ID to match.
      * @returns `true` if the next event has the given ID. Returns `false` otherwise.

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/events/EventTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/events/EventTest.kt
@@ -2,22 +2,24 @@ package it.krzeminski.snakeyaml.engine.kmp.events
 
 import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.shouldBe
 import it.krzeminski.snakeyaml.engine.kmp.common.Anchor
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.Mark
 
 class EventTest : FunSpec({
     test("toString") {
-        val alias = AliasEvent(Anchor("111"))
-        // This assertion is always true.
-        // TODO: clarify it within https://github.com/krzema12/snakeyaml-engine-kmp/issues/541
-        alias shouldNotBe alias.toString()
+        val alias = AliasEvent(Anchor("id1"))
+        alias.toString() shouldBe "=ALI *id1"
     }
 
     test("both marks") {
         val fake = Mark("a", 0, 0, 0, emptyList(), 0)
         shouldThrowWithMessage<NullPointerException>(message = "Both marks must be either present or absent.") {
             StreamStartEvent(startMark = null, endMark = fake)
+        }
+        // The other way around
+        shouldThrowWithMessage<NullPointerException>(message = "Both marks must be either present or absent.") {
+            StreamStartEvent(startMark = fake, endMark = null)
         }
     }
 })

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue46/JRubyPsychTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue46/JRubyPsychTest.kt
@@ -3,9 +3,7 @@ package it.krzeminski.snakeyaml.engine.kmp.issues.issue46
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import it.krzeminski.snakeyaml.engine.kmp.api.Load
-import it.krzeminski.snakeyaml.engine.kmp.exceptions.ScannerException
 
 /**
  * https://github.com/jruby/jruby/issues/7698
@@ -18,23 +16,18 @@ class JRubyPsychTest : FunSpec({
         parse("\u2028", "\n\u2028")
         parse("\u2029 1", "\n\u2029 1")
 
-        crash("while scanning an alias", "\n\u2029* ") // empty alias is not accepted
-        crash("while scanning an alias", "\n\u2029*") // empty alias is not accepted
-        crash("while scanning an alias", "\n\u2029* 1") // empty alias is not accepted
+        parse("\u2029*", "\n\u2029* ") // empty alias
+        parse("\u2029*", "\n\u2029*") // empty alias
+        parse("\u2029* 1", "\n\u2029* 1")
     }
 
     test("parse document where 2028 is used as leading space (3rd)") {
         val load = Load()
-        val obj = load.loadAll("--- |2-\n\n\u2028  * C\n")
-        obj.shouldNotBeNull()
-        val iter = obj as Iterable<*>
-        try {
-            iter.iterator().next()
-        } catch (e: ScannerException) {
-            // There's a bug in the test in snakeyaml-engine (source of this ported test), and the above line doesn't throw this exception (at least in some cases)
-            // TODO: report it to snakeyaml-engine's owner: https://github.com/krzema12/snakeyaml-engine-kmp/issues/541
-            e.message shouldContain " the leading empty lines contain more spaces (2) than the first non-empty line."
-        }
+        val docs = load.loadAll("--- |2-\n\n\u2028  * C\n")
+        docs.shouldNotBeNull()
+        val iter = docs as Iterable<*>
+        val doc = iter.iterator().next()
+        doc.shouldNotBeNull()
     }
 
     test("parse document") {
@@ -69,15 +62,4 @@ private fun parse(expected: Any, data: String) {
     val load = Load()
     val obj = load.loadOne(data)
     obj shouldBe expected
-}
-
-private fun crash(expectedError: String, data: String) {
-    val load = Load()
-    try {
-        load.loadOne(data)
-    } catch (e: Exception) {
-        // There's a bug in the test in snakeyaml-engine (source of this ported test), and the above line doesn't throw this exception (at least in some cases)
-        // TODO: report it to snakeyaml-engine's owner: https://github.com/krzema12/snakeyaml-engine-kmp/issues/541
-        e.message shouldContain expectedError
-    }
 }


### PR DESCRIPTION
Fixes https://github.com/krzema12/snakeyaml-engine-kmp/issues/563.

Ports:
* https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/5e8486729005e897158578d1ea5fb8965b1e491e
* https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/a9f31e749f27c801efb25a3cd04c934713fbb28e
* https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/e6f37163e5830595fa3e9f89270c8c2580154359
* https://bitbucket.org/snakeyaml/snakeyaml-engine/commits/33ad7e6a415c2b6b15714ff7f9b4f6d617e67c8d