### PR TITLE
Add tests for failing parsing comment after alias

### DIFF
--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue68/CommentAfterAliasTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue68/CommentAfterAliasTest.kt
@@ -9,86 +9,71 @@ import it.krzeminski.snakeyaml.engine.kmp.api.lowlevel.Compose
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.ParserException
 
 class CommentAfterAliasTest : FunSpec({
-    context("parsing comments is disabled") {
-        val loadSettings = LoadSettings.builder().setParseComments(false).build()
+    listOf(false, true).forEach { parseComments ->
+        val loadSettings = LoadSettings.builder().setParseComments(parseComments).build()
 
-        test("inline") {
+        test("inline when parsing comments enabled: $parseComments") {
             val compose = Compose(loadSettings)
             val input = """
             |field_with_alias: &alias_name # inline comment 1
             |  555""".trimMargin()
-            val node = compose.compose(input)
-            node.shouldNotBeNull()
+
+            if (parseComments) {
+                // This test shows a certain undesired behavior that ideally should be fixed one day.
+                // See https://github.com/krzema12/snakeyaml-engine-kmp/issues/478.
+                shouldThrow<ParserException> {
+                    compose.compose(input)
+                }.also {
+                    it.message shouldContain "while parsing a block mapping"
+                    it.message shouldContain "expected <block end>, but found '<scalar>'"
+                }
+            } else {
+                val node = compose.compose(input)
+                node.shouldNotBeNull()
+            }
         }
 
-        test("block comment and flat after") {
+        test("block comment and flat after when parsing comments enabled: $parseComments") {
             val compose = Compose(loadSettings)
             val input = """
             |field_with_alias: &alias_name
             |# separate line comment following the alias
             |    555""".trimMargin()
-            val node = compose.compose(input)
-            node.shouldNotBeNull()
+
+            if (parseComments) {
+                // This test shows a certain undesired behavior that ideally should be fixed one day.
+                // See https://github.com/krzema12/snakeyaml-engine-kmp/issues/478.
+                shouldThrow<ParserException> {
+                    compose.compose(input)
+                }.also {
+                    it.message shouldContain "while parsing a block mapping"
+                    it.message shouldContain "expected <block end>, but found '<scalar>'"
+                }
+            } else {
+                val node = compose.compose(input)
+                node.shouldNotBeNull()
+            }
         }
 
-        test("block comment and nested after") {
+        test("block comment and nested after when parsing comments enabled: $parseComments") {
             val compose = Compose(loadSettings)
             val input = """
             |field_with_alias: &alias_name
             |# separate line comment following the alias
             |    nested_field: nested_value""".trimMargin()
-            val node = compose.compose(input)
-            node.shouldNotBeNull()
-        }
-    }
 
-    context("parsing comments is enabled") {
-        val loadSettings = LoadSettings.builder().setParseComments(true).build()
-
-        test("inline") {
-            val compose = Compose(loadSettings)
-            val input = """
-            |field_with_alias: &alias_name # inline comment 1
-            |  555""".trimMargin()
-            // This test shows a certain undesired behavior that ideally should be fixed one day.
-            // See https://github.com/krzema12/snakeyaml-engine-kmp/issues/478.
-            shouldThrow<ParserException> {
-                compose.compose(input)
-            }.also {
-                it.message shouldContain "while parsing a block mapping"
-                it.message shouldContain "expected <block end>, but found '<scalar>'"
-            }
-        }
-
-        test("block comment and flat after") {
-            val compose = Compose(loadSettings)
-            val input = """
-            |field_with_alias: &alias_name
-            |# separate line comment following the alias
-            |    555""".trimMargin()
-            // This test shows a certain undesired behavior that ideally should be fixed one day.
-            // See https://github.com/krzema12/snakeyaml-engine-kmp/issues/478.
-            shouldThrow<ParserException> {
-                compose.compose(input)
-            }.also {
-                it.message shouldContain "while parsing a block mapping"
-                it.message shouldContain "expected <block end>, but found '<scalar>'"
-            }
-        }
-
-        test("block comment and nested after") {
-            val compose = Compose(loadSettings)
-            val input = """
-            |field_with_alias: &alias_name
-            |# separate line comment following the alias
-            |    nested_field: nested_value""".trimMargin()
-            // This test shows a certain undesired behavior that ideally should be fixed one day.
-            // See https://github.com/krzema12/snakeyaml-engine-kmp/issues/478.
-            shouldThrow<ParserException> {
-                compose.compose(input)
-            }.also {
-                it.message shouldContain "while parsing a block mapping"
-                it.message shouldContain "expected <block end>, but found '<block mapping start>'"
+            if (parseComments) {
+                // This test shows a certain undesired behavior that ideally should be fixed one day.
+                // See https://github.com/krzema12/snakeyaml-engine-kmp/issues/478.
+                shouldThrow<ParserException> {
+                    compose.compose(input)
+                }.also {
+                    it.message shouldContain "while parsing a block mapping"
+                    it.message shouldContain "expected <block end>, but found '<block mapping start>'"
+                }
+            } else {
+                val node = compose.compose(input)
+                node.shouldNotBeNull()
             }
         }
     }


### PR DESCRIPTION
These tests present certain undesired behavior that was reported in https://github.com/krzema12/snakeyaml-engine-kmp/issues/478 but ultimately wasn't fixed in the upstream project.

Easier to review when "Hide whitespace" option is turned on in the diff view.