### PR TITLE
Treat Kotlin compilation warnings as errors

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/lang/kotlin-multiplatform.gradle.kts
@@ -120,6 +120,7 @@ kotlin.targets.withType<KotlinJvmTarget>().configureEach {
     @OptIn(ExperimentalKotlinGradlePluginApi::class)
     compilerOptions {
         jvmTarget = JvmTarget(minSupportedJavaVersion)
+        allWarningsAsErrors = true
         freeCompilerArgs.addAll(
             "-Xjdk-release=${minSupportedJavaVersion.majorVersion}",
         )
@@ -139,6 +140,7 @@ kotlin.targets.withType<KotlinJvmTarget>().configureEach {
 tasks.named<KotlinJvmCompile>("compileTestKotlinJvm") {
     compilerOptions {
         jvmTarget = JvmTarget(javaForTests)
+        allWarningsAsErrors = true
         freeCompilerArgs.addAll(
             "-Xjdk-release=${javaForTests.majorVersion}",
         )

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadSettingsTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadSettingsTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.api
 
 import io.kotest.assertions.throwables.shouldThrow

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue11/TabInFlowContextTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue11/TabInFlowContextTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.issues.issue11
 
 import io.kotest.assertions.throwables.shouldThrow

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue17/WindowsLinesTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue17/WindowsLinesTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.issues.issue17
 
 import io.kotest.core.spec.style.FunSpec

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue69/TabInDoubleQuoteTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue69/TabInDoubleQuoteTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.issues.issue69
 
 import io.kotest.core.spec.style.FunSpec

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/colon_in_flow_context/ColonInFlowContextInListTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/colon_in_flow_context/ColonInFlowContextInListTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.usecases.colon_in_flow_context
 
 import io.kotest.core.spec.style.FunSpec

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/colon_in_flow_context/ColonInFlowContextInMapTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/colon_in_flow_context/ColonInFlowContextInMapTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.usecases.colon_in_flow_context
 
 import io.kotest.core.spec.style.FunSpec

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/custom_collections/CustomDefaultCollectionsTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/custom_collections/CustomDefaultCollectionsTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.usecases.custom_collections
 
 import io.kotest.core.spec.style.FunSpec

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/recursive/RecursiveMapTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/recursive/RecursiveMapTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.usecases.recursive
 
 import io.kotest.assertions.throwables.shouldThrowWithMessage

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/tags/LocalTagTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/tags/LocalTagTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.usecases.tags
 
 import io.kotest.core.spec.style.FunSpec

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/tags/SetsTagTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/tags/SetsTagTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.usecases.tags
 
 import io.kotest.core.spec.style.FunSpec

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/tags/TimestampTagTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/tags/TimestampTagTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.usecases.tags
 
 import io.kotest.core.spec.style.FunSpec

--- a/src/jvmTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/types/OptionalTest.kt
+++ b/src/jvmTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/types/OptionalTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.api.types
 
 import io.kotest.core.spec.style.FunSpec

--- a/src/jvmTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue44/ProtectedClassesTest.kt
+++ b/src/jvmTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue44/ProtectedClassesTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.issues.issue44
 
 import io.kotest.core.spec.style.FunSpec

--- a/src/jvmTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/binary/BinaryRoundTripTest.kt
+++ b/src/jvmTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/binary/BinaryRoundTripTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UNCHECKED_CAST")
 package it.krzeminski.snakeyaml.engine.kmp.usecases.binary
 
 import io.kotest.core.spec.style.FunSpec


### PR DESCRIPTION
When browsing the build logs (e.g. [here](https://github.com/krzema12/snakeyaml-engine-kmp/actions/runs/18216126100/job/51865697913)), warnings clutter the log, especially that in a single log, Kotlin compiles the code for several targets. It's also visible when e.g. running the tests in the IDE, and is a source of distraction.

Let's make the logs clean and forbid having unaddressed warnings.