### PR TITLE
Remove printing from tests

### DIFF
--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedMarkTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/usecases/inherited/InheritedMarkTest.kt
@@ -16,7 +16,6 @@ class InheritedMarkTest: FunSpec({
             // delimiter, as an empty string.
             .dropWhile { it.isEmpty() }
         inputs.forEach { input ->
-            println("Input: '$input'")
             var index = 0
             var line = 0
             var column = 0


### PR DESCRIPTION
This is the only standard output printing happening unconditionally in the tests. It adds to already noisy test logs, and I think it's fine to remove.