### PR TITLE
Fix Issue 75 - YAML 1.2 printable range compliance (port from upstream)

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/utils/Character.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/internal/utils/Character.kt
@@ -51,7 +51,7 @@ internal object Character {
     internal fun isSupplementaryCodePoint(codePoint: Int): Boolean =
         codePoint in MIN_SUPPLEMENTARY_CODE_POINT..MAX_CODE_POINT
 
-    internal fun charCount(codePoint: Int): Int = if (codePoint <= MIN_SUPPLEMENTARY_CODE_POINT) 1 else 2
+    internal fun charCount(codePoint: Int): Int = if (codePoint < MIN_SUPPLEMENTARY_CODE_POINT) 1 else 2
 
     internal fun isValidCodePoint(codePoint: Int): Boolean = codePoint in MIN_CODE_POINT..MAX_CODE_POINT
 

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ScannerImpl.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ScannerImpl.kt
@@ -1064,6 +1064,15 @@ class ScannerImpl(
         reader.forward()
         var length = 0
         while (CharConstants.NULL_OR_LINEBR.hasNo(reader.peek(length))) {
+            val c = reader.peek(length)
+            if (c == 0x7F) {
+                throw ScannerException(
+                    context = "while scanning a comment",
+                    contextMark = startMark,
+                    problem = "DEL character (0x7F) is not allowed in comments",
+                    problemMark = reader.getMark(),
+                )
+            }
             length++
         }
         val value = reader.prefixForward(length)
@@ -1469,6 +1478,15 @@ class ScannerImpl(
             val leadingNonSpace = reader.peek().toChar() !in " \t"
             var length = 0
             while (CharConstants.NULL_OR_LINEBR.hasNo(reader.peek(length))) {
+                val c = reader.peek(length)
+                if (c == 0x7F) {
+                    throw ScannerException(
+                        context = "while scanning a block scalar",
+                        contextMark = startMark,
+                        problem = "DEL character (0x7F) is not allowed in block scalars",
+                        problemMark = reader.getMark(),
+                    )
+                }
                 length++
             }
             stringBuilder.append(reader.prefixForward(length))
@@ -1888,6 +1906,14 @@ class ScannerImpl(
             }
             while (true) {
                 c = reader.peek(length)
+                if (c == 0x7F) {
+                    throw ScannerException(
+                        context = "while scanning a plain scalar",
+                        contextMark = startMark,
+                        problem = "DEL character (0x7F) is not allowed in plain scalars",
+                        problemMark = reader.getMark(),
+                    )
+                }
                 if (
                     CharConstants.NULL_BL_T_LINEBR.has(c)
                     || c == ':'.code

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReader.kt
@@ -293,7 +293,7 @@ class StreamReader(
          */
         @JvmStatic
         fun isPrintable(c: Int): Boolean {
-            return c in 0x20..0x7E
+            return c in 0x20..0x7F
                     || c == 0x9
                     || c == 0xA
                     || c == 0xD

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue75/EscapeCharInDoubleQuoteTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue75/EscapeCharInDoubleQuoteTest.kt
@@ -1,0 +1,62 @@
+@file:Suppress("UNCHECKED_CAST")
+package it.krzeminski.snakeyaml.engine.kmp.issues.issue75
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import it.krzeminski.snakeyaml.engine.kmp.api.Load
+import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
+import it.krzeminski.snakeyaml.engine.kmp.exceptions.ScannerException
+
+class EscapeCharInDoubleQuoteTest : FunSpec({
+    val load = Load(LoadSettings())
+
+    test("DEL allowed in double-quoted scalar") {
+        val str = "\"\u007F\""
+        val parsed = load.loadOne(str) as String
+        parsed shouldBe "\u007F"
+    }
+
+    test("DEL allowed in single-quoted scalar") {
+        val str = "'\u007F'"
+        val parsed = load.loadOne(str) as String
+        parsed shouldBe "\u007F"
+    }
+
+    test("DEL rejected in plain scalar value") {
+        val str = "key: \u007F"
+        shouldThrow<ScannerException> {
+            load.loadOne(str)
+        }
+    }
+
+    test("DEL rejected in plain scalar key") {
+        val str = "ke\u007Fy: value"
+        shouldThrow<ScannerException> {
+            load.loadOne(str)
+        }
+    }
+
+    test("DEL rejected in comment") {
+        val settings = LoadSettings(parseComments = true)
+        val loadWithComments = Load(settings)
+        val str = "key: value # comment with \u007F"
+        shouldThrow<ScannerException> {
+            loadWithComments.loadOne(str)
+        }
+    }
+
+    test("DEL rejected in literal block scalar") {
+        val str = "|\n  text with \u007F"
+        shouldThrow<ScannerException> {
+            load.loadOne(str)
+        }
+    }
+
+    test("DEL rejected in folded block scalar") {
+        val str = ">\n  text with \u007F"
+        shouldThrow<ScannerException> {
+            load.loadOne(str)
+        }
+    }
+})

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue75/EscapeCharInDoubleQuoteTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/issues/issue75/EscapeCharInDoubleQuoteTest.kt
@@ -4,6 +4,7 @@ package it.krzeminski.snakeyaml.engine.kmp.issues.issue75
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import it.krzeminski.snakeyaml.engine.kmp.api.Load
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.ScannerException
@@ -27,6 +28,8 @@ class EscapeCharInDoubleQuoteTest : FunSpec({
         val str = "key: \u007F"
         shouldThrow<ScannerException> {
             load.loadOne(str)
+        }.also {
+            it.message shouldContain "DEL character (0x7F) is not allowed in plain scalars"
         }
     }
 
@@ -34,6 +37,8 @@ class EscapeCharInDoubleQuoteTest : FunSpec({
         val str = "ke\u007Fy: value"
         shouldThrow<ScannerException> {
             load.loadOne(str)
+        }.also {
+            it.message shouldContain "DEL character (0x7F) is not allowed in plain scalars"
         }
     }
 
@@ -43,6 +48,8 @@ class EscapeCharInDoubleQuoteTest : FunSpec({
         val str = "key: value # comment with \u007F"
         shouldThrow<ScannerException> {
             loadWithComments.loadOne(str)
+        }.also {
+            it.message shouldContain "DEL character (0x7F) is not allowed in comments"
         }
     }
 
@@ -50,6 +57,8 @@ class EscapeCharInDoubleQuoteTest : FunSpec({
         val str = "|\n  text with \u007F"
         shouldThrow<ScannerException> {
             load.loadOne(str)
+        }.also {
+            it.message shouldContain "DEL character (0x7F) is not allowed in block scalars"
         }
     }
 
@@ -57,6 +66,8 @@ class EscapeCharInDoubleQuoteTest : FunSpec({
         val str = ">\n  text with \u007F"
         shouldThrow<ScannerException> {
             load.loadOne(str)
+        }.also {
+            it.message shouldContain "DEL character (0x7F) is not allowed in block scalars"
         }
     }
 })

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReaderHighSurrogateTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReaderHighSurrogateTest.kt
@@ -6,10 +6,6 @@ import io.kotest.matchers.shouldBe
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 
 /**
- * Ported from snakeyaml-engine [StreamReaderHighSurrogateTest](
- * https://github.com/snakeyaml/snakeyaml-engine/blob/master/src/test/java/org/snakeyaml/engine/v2/scanner/StreamReaderHighSurrogateTest.java
- * )
- *
  * Tests that the StreamReader correctly handles high surrogates at buffer boundaries and does not
  * throw IndexOutOfBoundsException or misinterpret surrogate pairs.
  */

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReaderHighSurrogateTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReaderHighSurrogateTest.kt
@@ -5,30 +5,63 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 
+/**
+ * Ported from snakeyaml-engine [StreamReaderHighSurrogateTest](
+ * https://github.com/snakeyaml/snakeyaml-engine/blob/master/src/test/java/org/snakeyaml/engine/v2/scanner/StreamReaderHighSurrogateTest.java
+ * )
+ *
+ * Tests that the StreamReader correctly handles high surrogates at buffer boundaries and does not
+ * throw IndexOutOfBoundsException or misinterpret surrogate pairs.
+ */
 class StreamReaderHighSurrogateTest : FunSpec({
+    /**
+     * Test for IndexOutOfBoundsException when buffer is exactly filled with 1025 code points and the
+     * last code point is a supplementary character represented as a surrogate pair.
+     * This reproduces the bug where `buffer[1025]` is accessed on a buffer with length 1025 in the
+     * upstream Java code (where the buffer was sized for chars, not code points).
+     *
+     * In the Kotlin version, the analogous bug was an off-by-one in [Character.charCount] where
+     * `charCount(0x10000)` returned 1 instead of 2, causing the low surrogate to be processed as a
+     * standalone code point and rejected by the printable check.
+     */
     test("high surrogate at buffer boundary") {
+        // Create a string that is exactly 1024 regular code points + 1 supplementary code point
+        // represented as a surrogate pair (2 Java chars = 1 Kotlin code point)
         val sb = StringBuilder()
+
+        // Fill with 1024 regular ASCII characters
         for (i in 0..<1024) {
             sb.append('a')
         }
-        sb.append('\uD800')
-        sb.append('\uDC00')
 
+        // Add a supplementary code point as a surrogate pair
+        sb.append('\uD800') // High surrogate
+        sb.append('\uDC00') // Low surrogate
+
+        // This should not throw
         val settings = LoadSettings(bufferSize = 1024)
         val reader = StreamReader(settings, sb.toString())
 
+        // Read all code points - this would trigger the bug before the fix
         var count = 0
         while (reader.peek() != 0) {
             reader.forward(1)
             count++
         }
+
+        // We should successfully read all 1025 code points (1024 ASCII + 1 supplementary)
         withClue("Should read 1025 code points (1024 ASCII + 1 supplementary)") {
             count shouldBe 1025
         }
     }
 
+    /**
+     * Test with multiple buffer fills where the boundary character is a high surrogate.
+     * Ensures surrogate pairs are correctly handled across multiple buffer read cycles.
+     */
     test("high surrogate at multiple buffer boundaries") {
         val settings = LoadSettings(bufferSize = 10)
+        // Create a string where the 10th character triggers a buffer boundary mid-surrogate-pair
         val input = "123456789\uD800\uDC00abcdefghij\uD801\uDC01xyz"
 
         val reader = StreamReader(settings, input)
@@ -38,6 +71,9 @@ class StreamReaderHighSurrogateTest : FunSpec({
             reader.forward(1)
             count++
         }
+
+        // Count should match the number of code points
+        // 9 regular + 1 surrogate pair + 10 regular + 1 surrogate pair + 3 regular = 24 code points
         withClue("Should read 24 code points") {
             count shouldBe 24
         }

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReaderHighSurrogateTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/StreamReaderHighSurrogateTest.kt
@@ -1,0 +1,45 @@
+package it.krzeminski.snakeyaml.engine.kmp.scanner
+
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
+
+class StreamReaderHighSurrogateTest : FunSpec({
+    test("high surrogate at buffer boundary") {
+        val sb = StringBuilder()
+        for (i in 0..<1024) {
+            sb.append('a')
+        }
+        sb.append('\uD800')
+        sb.append('\uDC00')
+
+        val settings = LoadSettings(bufferSize = 1024)
+        val reader = StreamReader(settings, sb.toString())
+
+        var count = 0
+        while (reader.peek() != 0) {
+            reader.forward(1)
+            count++
+        }
+        withClue("Should read 1025 code points (1024 ASCII + 1 supplementary)") {
+            count shouldBe 1025
+        }
+    }
+
+    test("high surrogate at multiple buffer boundaries") {
+        val settings = LoadSettings(bufferSize = 10)
+        val input = "123456789\uD800\uDC00abcdefghij\uD801\uDC01xyz"
+
+        val reader = StreamReader(settings, input)
+
+        var count = 0
+        while (reader.peek() != 0) {
+            reader.forward(1)
+            count++
+        }
+        withClue("Should read 24 code points") {
+            count shouldBe 24
+        }
+    }
+})


### PR DESCRIPTION
## Summary

Ports four upstream commits from [snakeyaml/snakeyaml-engine](https://github.com/snakeyaml/snakeyaml-engine) that fix character handling and YAML 1.2 printable range compliance for Issue 75.

## Ported commits

| Commit | Description |
|--------|-------------|
| [snakeyaml-engine@06b1c92](https://github.com/snakeyaml/snakeyaml-engine/commit/06b1c92) | Add initial test for issue 75 (DEL in double-quoted scalar) |
| [snakeyaml-engine@2c85c8c](https://github.com/snakeyaml/snakeyaml-engine/commit/2c85c8c) | Allow 0x7F in `StreamReader.isPrintable()` |
| [snakeyaml-engine@c1d4d3c](https://github.com/snakeyaml/snakeyaml-engine/commit/c1d4d3c) | Reject 0x7F in plain scalars, comments, block scalars (`ScannerImpl`) + update test |
| [snakeyaml-engine@cedf62b](https://github.com/snakeyaml/snakeyaml-engine/commit/cedf62b) | Adapt surrogate pair boundary fix (Kotlin equivalent: off-by-one in `Character.charCount`) |

## Changes

### StreamReader.kt — Allow 0x7F as printable (commit `2c85c8c`)
Changed `isPrintable()` range from `0x20..0x7E` to `0x20..0x7F`, allowing the DEL character through the stream reader. This is required per the YAML 1.2 `nb-json` production, which applies to double-quoted and single-quoted strings.

### ScannerImpl.kt — Reject 0x7F in non-quoted contexts (commit `c1d4d3c`)
Added DEL character validation in three methods to enforce YAML 1.2 `c-printable` production rules:
- `scanComment()` — rejects DEL in comments
- `scanBlockScalar()` — rejects DEL in literal/folded block scalars
- `scanPlain()` — rejects DEL in plain scalars

Each throws a `ScannerException` with a descriptive message when 0x7F is encountered.

### Character.kt — Fix surrogate pair boundary (adaptation of commit `cedf62b`)
Fixed `charCount()` boundary: changed `<=` to `<` for `MIN_SUPPLEMENTARY_CODE_POINT`, so `charCount(0x10000)` correctly returns 2 instead of 1. The upstream Java fix was a `Reader.read` buffer sizing change; the Kotlin equivalent manifested as an off-by-one that caused surrogate pairs at U+10000 to be misinterpreted as two separate code points, with the low surrogate failing the printable check.

### Tests (commits `06b1c92` + `c1d4d3c`)
- **StreamReaderHighSurrogateTest.kt** — Verifies surrogate pairs at buffer boundaries are handled without errors
- **EscapeCharInDoubleQuoteTest.kt** — 7 test cases covering:
  - DEL allowed in double-quoted scalars
  - DEL allowed in single-quoted scalars
  - DEL rejected in plain scalar values and keys
  - DEL rejected in comments
  - DEL rejected in literal and folded block scalars
