### PR TITLE
Port upstream 8876c5c (Issue 72) - allowNonScalarKeys setting

### DIFF
--- a/api/snakeyaml-engine-kmp.api
+++ b/api/snakeyaml-engine-kmp.api
@@ -72,9 +72,10 @@ public final class it/krzeminski/snakeyaml/engine/kmp/api/Load {
 
 public final class it/krzeminski/snakeyaml/engine/kmp/api/LoadSettings {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/util/Map;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$SpecVersionMutator;IZZIZLjava/util/Map;Lit/krzeminski/snakeyaml/engine/kmp/env/EnvConfig;ZILit/krzeminski/snakeyaml/engine/kmp/schema/Schema;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$SpecVersionMutator;IZZIZLjava/util/Map;Lit/krzeminski/snakeyaml/engine/kmp/env/EnvConfig;ZILit/krzeminski/snakeyaml/engine/kmp/schema/Schema;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$SpecVersionMutator;IZZZIZLjava/util/Map;Lit/krzeminski/snakeyaml/engine/kmp/env/EnvConfig;ZILit/krzeminski/snakeyaml/engine/kmp/schema/Schema;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$CollectionProvider;Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$SpecVersionMutator;IZZZIZLjava/util/Map;Lit/krzeminski/snakeyaml/engine/kmp/env/EnvConfig;ZILit/krzeminski/snakeyaml/engine/kmp/schema/Schema;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAllowDuplicateKeys ()Z
+	public final fun getAllowNonScalarKeys ()Z
 	public final fun getAllowRecursiveKeys ()Z
 	public final fun getBufferSize ()I
 	public final fun getCodePointLimit ()I
@@ -155,6 +156,7 @@ public abstract interface class it/krzeminski/snakeyaml/engine/kmp/api/MutableDu
 
 public abstract interface class it/krzeminski/snakeyaml/engine/kmp/api/MutableLoadSettings {
 	public abstract fun getAllowDuplicateKeys ()Z
+	public abstract fun getAllowNonScalarKeys ()Z
 	public abstract fun getAllowRecursiveKeys ()Z
 	public abstract fun getBufferSize ()I
 	public abstract fun getCodePointLimit ()I
@@ -171,6 +173,7 @@ public abstract interface class it/krzeminski/snakeyaml/engine/kmp/api/MutableLo
 	public abstract fun getUseMarks ()Z
 	public abstract fun getVersionFunction ()Lit/krzeminski/snakeyaml/engine/kmp/api/LoadSettings$SpecVersionMutator;
 	public abstract fun setAllowDuplicateKeys (Z)V
+	public abstract fun setAllowNonScalarKeys (Z)V
 	public abstract fun setAllowRecursiveKeys (Z)V
 	public abstract fun setBufferSize (I)V
 	public abstract fun setCodePointLimit (I)V

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,6 @@ dependencies {
     kspCommonMainMetadata(projects.copyDslKspProcessor)
 }
 
-
-
 kotlin {
     sourceSets {
         commonMain {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     kspCommonMainMetadata(projects.copyDslKspProcessor)
 }
 
+
+
 kotlin {
     sourceSets {
         commonMain {

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadSettings.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/api/LoadSettings.kt
@@ -94,6 +94,15 @@ class LoadSettings(
     val allowRecursiveKeys: Boolean = false,
 
     /**
+     * Non-scalar keys in a mapping may cause issues when used with an untrusted source. Since using a
+     * collection as a key in mapping is a relatively rare use case (and it is not supported in JSON),
+     * this possibility can be switched off.
+     *
+     * True by default for backward compatibility.
+     */
+    val allowNonScalarKeys: Boolean = true,
+
+    /**
      * Restrict the number of aliases for collection nodes to prevent 'billion laughs attack'. The
      * purpose of this setting is to force SnakeYAML to fail before a lot of CPU and memory resources
      * are allocated for the parser. Aliases for scalar nodes do not count because they do not grow

--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/composer/Composer.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/composer/Composer.kt
@@ -334,6 +334,9 @@ class Composer(
      */
     private fun composeMappingChildren(children: MutableList<NodeTuple>, node: MappingNode) {
         val itemKey = composeKeyNode(node)
+        if (itemKey.nodeType != NodeType.SCALAR && !settings.allowNonScalarKeys) {
+            throw YamlEngineException("Non scalar key is detected but it is not configured to be allowed.")
+        }
         if (itemKey.tag == Tag.MERGE) {
             node.hasMergeTag = true
         }

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/composer/ComposerTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/composer/ComposerTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import it.krzeminski.snakeyaml.engine.kmp.api.LoadSettings
 import it.krzeminski.snakeyaml.engine.kmp.api.lowlevel.Compose
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.ComposerException
+import it.krzeminski.snakeyaml.engine.kmp.exceptions.YamlEngineException
 
 class ComposerTest : FunSpec({
 
@@ -25,6 +26,14 @@ class ComposerTest : FunSpec({
             Compose(LoadSettings()).compose("[a, *id b]")
         }.also {
             it.message shouldContain "found undefined alias id"
+        }
+    }
+
+    test("fail to compose non-scalar key") {
+        shouldThrow<YamlEngineException> {
+            Compose(LoadSettings(allowNonScalarKeys = false)).compose("{ [1,2]: value}")
+        }.also {
+            it.message shouldBe "Non scalar key is detected but it is not configured to be allowed."
         }
     }
 


### PR DESCRIPTION
Port upstream commit [8876c5c](https://github.com/snakeyaml/snakeyaml-engine/commit/8876c5c) (Issue 72) - adds an allowNonScalarKeys setting to LoadSettings and enforces it in Composer.composeMappingChildren. Includes a test for the new behavior.

**⚠️ Intentional divergence from upstream:** The upstream default is `false` (security-conscious), but this KMP port defaults to `true` for backward compatibility with existing YAML documents that use non-scalar mapping keys. Users coming from upstream should explicitly set `allowNonScalarKeys = false` if they want the safer default.