### PR TITLE
Port upstream 9810a28 (Issue 76) - consecutive TABs handling

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ScannerImpl.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/scanner/ScannerImpl.kt
@@ -1011,8 +1011,8 @@ class ScannerImpl(
             }
             // unfortunately, this check is too simple, but it helps to ignore TABs in JSON
             // which is always flow context (see issue 55 and tests)
-            if (reader.peek(ff) == '\t'.code && isFlowContext()) {
-                ff++;
+            while (reader.peek(ff) == '\t'.code && isFlowContext()) {
+                ff++
             }
             // In block context, tabs that are not acting as indentation should be
             // treated as separator whitespace. This covers lines that contain only


### PR DESCRIPTION
Port upstream commit [9810a28](https://github.com/snakeyaml/snakeyaml-engine/commit/9810a28) (Issue 76) - changes if to while when scanning consecutive TAB characters in ScannerImpl.