### PR TITLE
Port upstream 9a01a3c - remove dead is ByteArray branch from representPrimitiveArray

### DIFF
--- a/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/representer/CommonRepresenter.kt
+++ b/src/commonMain/kotlin/it/krzeminski/snakeyaml/engine/kmp/representer/CommonRepresenter.kt
@@ -127,7 +127,6 @@ open class CommonRepresenter(
     private val representPrimitiveArray = RepresentToNode { data ->
         val style = settings.defaultFlowStyle
         val iterableData = when (data) {
-            is ByteArray    -> data.asIterable()
             is ShortArray   -> data.asIterable()
             is IntArray     -> data.asIterable()
             is LongArray    -> data.asIterable()

--- a/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/representer/StandardRepresenterTest.kt
+++ b/src/commonTest/kotlin/it/krzeminski/snakeyaml/engine/kmp/representer/StandardRepresenterTest.kt
@@ -16,9 +16,11 @@ package it.krzeminski.snakeyaml.engine.kmp.representer
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import it.krzeminski.snakeyaml.engine.kmp.api.Dump
 import it.krzeminski.snakeyaml.engine.kmp.api.DumpSettings
 import it.krzeminski.snakeyaml.engine.kmp.exceptions.YamlEngineException
 import it.krzeminski.snakeyaml.engine.kmp.nodes.Node
+import it.krzeminski.snakeyaml.engine.kmp.nodes.SequenceNode
 
 internal class StandardRepresenterTest : FunSpec({
     val standardRepresenter = Representer(DumpSettings())
@@ -32,6 +34,18 @@ internal class StandardRepresenterTest : FunSpec({
             )
         }
         exception.message shouldBe "Representer is not defined for class MyCustomClass"
+    }
+
+    test("Represent Iterator as node") {
+        val listOfStrings = listOf("hello", "world")
+        val iterator = listOfStrings.iterator()
+        val node: Node = standardRepresenter.represent(iterator)
+        node.tag.value shouldBe "tag:yaml.org,2002:seq"
+        val seq = node as SequenceNode
+        seq.value.size shouldBe 2
+        seq.value.forEach { it.tag.value shouldBe "tag:yaml.org,2002:str" }
+        val dumper = Dump(DumpSettings())
+        dumper.dumpToString(listOfStrings.iterator()) shouldBe "[hello, world]\n"
     }
 
     test("Represent Enum as node with global tag") {


### PR DESCRIPTION
Port upstream commit [9a01a3c](https://github.com/snakeyaml/snakeyaml-engine/commit/9a01a3c) - removes the dead is ByteArray branch from CommonRepresenter.representPrimitiveArray. In the KMP version, ByteArray is handled separately by representByteArray, so the is ByteArray branch in the when block is unreachable.