### PR TITLE
Downgrade Kotlin for GitHub workflows to 2.3.21

### DIFF
--- a/.github/workflows/benchmark.main.kts
+++ b/.github/workflows/benchmark.main.kts
@@ -120,6 +120,18 @@ workflow(
         // without checkout step 'benchmark-action/github-action-benchmark' action won't work
         uses(action = Checkout())
         uses(
+            name = "Downgrade Kotlin",
+            action = SetupKotlin(
+                // One version before 2.4.0 that contains a bug leading to this failure:
+                //   While analysing .github/workflows/build.main.kts:53:13:
+                //   org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments:
+                //   Expected FirResolvedTypeRef with ConeKotlinType but was FirUserTypeRefImpl
+                // This downgrade is meant to be a temporary workaround.
+                // See https://github.com/typesafegithub/github-workflows-kt/issues/2348
+                version = "2.3.21",
+            ),
+        )
+        uses(
             name = "Download benchmark results",
             action = DownloadArtifact(
                 pattern = "bench-results-*",

--- a/.github/workflows/benchmark.main.kts
+++ b/.github/workflows/benchmark.main.kts
@@ -9,6 +9,7 @@
 @file:DependsOn("actions:upload-artifact:v7")
 @file:DependsOn("gradle:actions__setup-gradle:v6")
 @file:DependsOn("benchmark-action:github-action-benchmark:v1")
+@file:DependsOn("fwilhe2:setup-kotlin:v1")
 
 @file:Import("setup-jdk.main.kts")
 
@@ -18,6 +19,7 @@ import io.github.typesafegithub.workflows.actions.actions.UploadArtifact
 import io.github.typesafegithub.workflows.actions.actions.SetupJava
 import io.github.typesafegithub.workflows.actions.actions.SetupJava.Distribution.Temurin
 import io.github.typesafegithub.workflows.actions.benchmarkaction.GithubActionBenchmark
+import io.github.typesafegithub.workflows.actions.fwilhe2.SetupKotlin
 import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
 import io.github.typesafegithub.workflows.annotations.ExperimentalKotlinLogicStep
 import io.github.typesafegithub.workflows.domain.Concurrency
@@ -27,6 +29,7 @@ import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
+import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonArray
@@ -44,6 +47,22 @@ workflow(
     on = listOf(
         Push(branches = listOf("main")),
         PullRequest()
+    ),
+    consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
+        additionalSteps = {
+            uses(
+                name = "Downgrade Kotlin",
+                action = SetupKotlin(
+                    // One version before 2.4.0 that contains a bug leading to this failure:
+                    //   While analysing .github/workflows/build.main.kts:53:13:
+                    //   org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments:
+                    //   Expected FirResolvedTypeRef with ConeKotlinType but was FirUserTypeRefImpl
+                    // This downgrade is meant to be a temporary workaround.
+                    // See https://github.com/typesafegithub/github-workflows-kt/issues/2348
+                    version = "2.3.21",
+                ),
+            )
+        },
     ),
     concurrency = Concurrency(
         group = "${expr { github.workflow }} @ ${expr { "${github.eventPullRequest.pull_request.head.label} || ${github.head_ref} || ${github.ref}" }}",

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -20,9 +20,14 @@ jobs:
       name: 'Check out'
       uses: 'actions/checkout@v4'
     - id: 'step-1'
+      name: 'Downgrade Kotlin'
+      uses: 'fwilhe2/setup-kotlin@v1'
+      with:
+        version: '2.3.21'
+    - id: 'step-2'
       name: 'Execute script'
       run: 'rm ''.github/workflows/benchmark.yaml'' && ''.github/workflows/benchmark.main.kts'''
-    - id: 'step-2'
+    - id: 'step-3'
       name: 'Consistency check'
       run: 'git diff --exit-code ''.github/workflows/benchmark.yaml'''
   run-benchmark:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -75,18 +75,23 @@ jobs:
     - id: 'step-0'
       uses: 'actions/checkout@v6'
     - id: 'step-1'
+      name: 'Downgrade Kotlin'
+      uses: 'fwilhe2/setup-kotlin@v1'
+      with:
+        version: '2.3.21'
+    - id: 'step-2'
       name: 'Download benchmark results'
       uses: 'actions/download-artifact@v8'
       with:
         path: 'bench-results'
         pattern: 'bench-results-*'
         merge-multiple: 'true'
-    - id: 'step-2'
+    - id: 'step-3'
       name: 'Prepare and join benchmark reports'
       env:
         GHWKT_GITHUB_CONTEXT_JSON: '${{ toJSON(github) }}'
-      run: 'GHWKT_RUN_STEP=''benchmark.yaml:collect-benchmarks-results:step-2'' ''.github/workflows/benchmark.main.kts'''
-    - id: 'step-3'
+      run: 'GHWKT_RUN_STEP=''benchmark.yaml:collect-benchmarks-results:step-3'' ''.github/workflows/benchmark.main.kts'''
+    - id: 'step-4'
       name: 'Store benchmark result'
       uses: 'benchmark-action/github-action-benchmark@v1'
       with:

--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -6,11 +6,13 @@
 @file:DependsOn("actions:checkout:v6")
 @file:DependsOn("actions:cache:v5")
 @file:DependsOn("gradle:actions__setup-gradle:v6")
+@file:DependsOn("fwilhe2:setup-kotlin:v1")
 
 @file:Import("setup-jdk.main.kts")
 
 import io.github.typesafegithub.workflows.actions.actions.Cache
 import io.github.typesafegithub.workflows.actions.actions.Checkout
+import io.github.typesafegithub.workflows.actions.fwilhe2.SetupKotlin
 import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
 import io.github.typesafegithub.workflows.domain.Concurrency
 import io.github.typesafegithub.workflows.domain.RunnerType.*
@@ -18,6 +20,7 @@ import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
+import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 
 workflow(
     name = "Build",
@@ -26,6 +29,22 @@ workflow(
         PullRequest(),
     ),
     sourceFile = __FILE__,
+    consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
+        additionalSteps = {
+            uses(
+                name = "Downgrade Kotlin",
+                action = SetupKotlin(
+                    // One version before 2.4.0 that contains a bug leading to this failure:
+                    //   While analysing .github/workflows/build.main.kts:53:13:
+                    //   org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments:
+                    //   Expected FirResolvedTypeRef with ConeKotlinType but was FirUserTypeRefImpl
+                    // This downgrade is meant to be a temporary workaround.
+                    // See https://github.com/typesafegithub/github-workflows-kt/issues/2348
+                    version = "2.3.21",
+                ),
+            )
+        },
+    ),
     concurrency = Concurrency(
         group = "\${{ github.workflow }} @ \${{ github.event.pull_request.head.label || github.head_ref || github.ref }}",
         cancelInProgress = true,

--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -94,6 +94,18 @@ workflow(
         runsOn = UbuntuLatest,
     ) {
         uses(action = Checkout())
+        uses(
+            name = "Downgrade Kotlin",
+            action = SetupKotlin(
+                // One version before 2.4.0 that contains a bug leading to this failure:
+                //   While analysing .github/workflows/build.main.kts:53:13:
+                //   org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments:
+                //   Expected FirResolvedTypeRef with ConeKotlinType but was FirUserTypeRefImpl
+                // This downgrade is meant to be a temporary workaround.
+                // See https://github.com/typesafegithub/github-workflows-kt/issues/2348
+                version = "2.3.21",
+            ),
+        )
         run(
             command = """
             find -name *.main.kts -print0 | while read -d ${'$'}'\0' file
@@ -111,6 +123,18 @@ workflow(
         runsOn = UbuntuLatest,
     ) {
         uses(action = Checkout())
+        uses(
+            name = "Downgrade Kotlin",
+            action = SetupKotlin(
+                // One version before 2.4.0 that contains a bug leading to this failure:
+                //   While analysing .github/workflows/build.main.kts:53:13:
+                //   org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments:
+                //   Expected FirResolvedTypeRef with ConeKotlinType but was FirUserTypeRefImpl
+                // This downgrade is meant to be a temporary workaround.
+                // See https://github.com/typesafegithub/github-workflows-kt/issues/2348
+                version = "2.3.21",
+            ),
+        )
         run(command = "cd .github/workflows")
         run(
             name = "Regenerate all workflow YAMLs",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,6 +120,11 @@ jobs:
     - id: 'step-0'
       uses: 'actions/checkout@v6'
     - id: 'step-1'
+      name: 'Downgrade Kotlin'
+      uses: 'fwilhe2/setup-kotlin@v1'
+      with:
+        version: '2.3.21'
+    - id: 'step-2'
       run: |-
         find -name *.main.kts -print0 | while read -d $'\0' file
         do
@@ -135,8 +140,13 @@ jobs:
     - id: 'step-0'
       uses: 'actions/checkout@v6'
     - id: 'step-1'
-      run: 'cd .github/workflows'
+      name: 'Downgrade Kotlin'
+      uses: 'fwilhe2/setup-kotlin@v1'
+      with:
+        version: '2.3.21'
     - id: 'step-2'
+      run: 'cd .github/workflows'
+    - id: 'step-3'
       name: 'Regenerate all workflow YAMLs'
       run: |-
         find -name "*.main.kts" -print0 | while read -d $'\0' file
@@ -146,6 +156,6 @@ jobs:
                 ($file)
             fi
         done
-    - id: 'step-3'
+    - id: 'step-4'
       name: 'Check if some file is different after regeneration'
       run: 'git diff --exit-code .'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,14 @@ jobs:
       name: 'Check out'
       uses: 'actions/checkout@v4'
     - id: 'step-1'
+      name: 'Downgrade Kotlin'
+      uses: 'fwilhe2/setup-kotlin@v1'
+      with:
+        version: '2.3.21'
+    - id: 'step-2'
       name: 'Execute script'
       run: 'rm ''.github/workflows/build.yaml'' && ''.github/workflows/build.main.kts'''
-    - id: 'step-2'
+    - id: 'step-3'
       name: 'Consistency check'
       run: 'git diff --exit-code ''.github/workflows/build.yaml'''
   build-on-UbuntuLatest:

--- a/.github/workflows/check-upstream.main.kts
+++ b/.github/workflows/check-upstream.main.kts
@@ -4,14 +4,17 @@
 
 @file:Repository("https://bindings.krzeminski.it/")
 @file:DependsOn("actions:checkout:v6")
+@file:DependsOn("fwilhe2:setup-kotlin:v1")
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout
+import io.github.typesafegithub.workflows.actions.fwilhe2.SetupKotlin
 import io.github.typesafegithub.workflows.domain.RunnerType
 import io.github.typesafegithub.workflows.domain.triggers.Cron
 import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.domain.triggers.Schedule
 import io.github.typesafegithub.workflows.domain.triggers.WorkflowDispatch
 import io.github.typesafegithub.workflows.dsl.workflow
+import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 
 val numberOfCommitsFileName = "number-of-commits.txt"
 val logDiffBetweenRepos = "log-diff-between-repos.txt"
@@ -25,6 +28,22 @@ workflow(
         Schedule(triggers = listOf(Cron(minute = "0", hour = "0", dayWeek = "6"))), // Once a week.
     ),
     sourceFile = __FILE__,
+    consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
+        additionalSteps = {
+            uses(
+                name = "Downgrade Kotlin",
+                action = SetupKotlin(
+                    // One version before 2.4.0 that contains a bug leading to this failure:
+                    //   While analysing .github/workflows/build.main.kts:53:13:
+                    //   org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments:
+                    //   Expected FirResolvedTypeRef with ConeKotlinType but was FirUserTypeRefImpl
+                    // This downgrade is meant to be a temporary workaround.
+                    // See https://github.com/typesafegithub/github-workflows-kt/issues/2348
+                    version = "2.3.21",
+                ),
+            )
+        },
+    ),
 ) {
     job(
         id = "check",

--- a/.github/workflows/check-upstream.yaml
+++ b/.github/workflows/check-upstream.yaml
@@ -19,9 +19,14 @@ jobs:
       name: 'Check out'
       uses: 'actions/checkout@v4'
     - id: 'step-1'
+      name: 'Downgrade Kotlin'
+      uses: 'fwilhe2/setup-kotlin@v1'
+      with:
+        version: '2.3.21'
+    - id: 'step-2'
       name: 'Execute script'
       run: 'rm ''.github/workflows/check-upstream.yaml'' && ''.github/workflows/check-upstream.main.kts'''
-    - id: 'step-2'
+    - id: 'step-3'
       name: 'Consistency check'
       run: 'git diff --exit-code ''.github/workflows/check-upstream.yaml'''
   check:

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -6,6 +6,7 @@
 @file:DependsOn("actions:checkout:v6")
 @file:DependsOn("actions:cache:v5")
 @file:DependsOn("gradle:actions__setup-gradle:v6")
+@file:DependsOn("fwilhe2:setup-kotlin:v1")
 
 @file:Import("setup-jdk.main.kts")
 
@@ -13,6 +14,7 @@ import io.github.typesafegithub.workflows.actions.actions.Cache
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.actions.SetupJava
 import io.github.typesafegithub.workflows.actions.actions.SetupJava.Distribution.Temurin
+import io.github.typesafegithub.workflows.actions.fwilhe2.SetupKotlin
 import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
 import io.github.typesafegithub.workflows.domain.RunnerType
 import io.github.typesafegithub.workflows.domain.triggers.Push
@@ -20,6 +22,7 @@ import io.github.typesafegithub.workflows.domain.triggers.WorkflowDispatch
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
+import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 
 val SONATYPE_USERNAME by Contexts.secrets
 val SONATYPE_PASSWORD by Contexts.secrets
@@ -34,6 +37,22 @@ workflow(
         WorkflowDispatch(),
     ),
     sourceFile = __FILE__,
+    consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
+        additionalSteps = {
+            uses(
+                name = "Downgrade Kotlin",
+                action = SetupKotlin(
+                    // One version before 2.4.0 that contains a bug leading to this failure:
+                    //   While analysing .github/workflows/build.main.kts:53:13:
+                    //   org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments:
+                    //   Expected FirResolvedTypeRef with ConeKotlinType but was FirUserTypeRefImpl
+                    // This downgrade is meant to be a temporary workaround.
+                    // See https://github.com/typesafegithub/github-workflows-kt/issues/2348
+                    version = "2.3.21",
+                ),
+            )
+        },
+    ),
 ) {
     job(
         id = "release",

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,9 +17,14 @@ jobs:
       name: 'Check out'
       uses: 'actions/checkout@v4'
     - id: 'step-1'
+      name: 'Downgrade Kotlin'
+      uses: 'fwilhe2/setup-kotlin@v1'
+      with:
+        version: '2.3.21'
+    - id: 'step-2'
       name: 'Execute script'
       run: 'rm ''.github/workflows/release.yaml'' && ''.github/workflows/release.main.kts'''
-    - id: 'step-2'
+    - id: 'step-3'
       name: 'Consistency check'
       run: 'git diff --exit-code ''.github/workflows/release.yaml'''
   release:


### PR DESCRIPTION
The goal is to unblock running CI until the problem is fixed in Kotlin.